### PR TITLE
Initial version updates to pick up recent C12 typography.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "brightspace-integration",
   "dependencies": {
     "jquery-vui-accordion": "~0.3.0",
-    "jquery-vui-collapsible-section": "~0.4.0",
+    "jquery-vui-collapsible-section": "~0.4.1",
     "jquery-vui-change-tracking": "~0.4.0",
     "jquery-vui-more-less": "~0.3.0",
     "jquery-vui-scrollspy": "~0.2.0",
@@ -11,11 +11,11 @@
     "vui-field": "~0.6.1",
     "vui-focus": "~0.7.1",
     "vui-icons": "~0.7.0",
-    "vui-input": "~0.7.0",
+    "vui-input": "~1.0.0",
     "vui-link": "~0.7.0",
     "vui-list": "~0.5.0",
     "vui-offscreen": "~0.3.0",
-    "vui-typography": "~0.6.0"
+    "vui-typography": "~1.0.2"
   },
   "private": true
 }


### PR DESCRIPTION
@dlockhart : these are initial version updates to pick up recent typography changes for C12.  Besides vui-typography, it also includes vui-input and jquery-vui-collapsible-section version updates since those components needed a couple small tweaks as a result of removing variables and changing the typography mixins.