### PR TITLE
Updated build pipeline to use clean-css and uglify-js over uglify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightspace-integration",
-  "version": "10.5.5",
+  "version": "10.5.6",
   "description": "Integration project for components consumed by Brightspace.",
   "private": true,
   "main": "src/index.js",
@@ -18,8 +18,8 @@
     "preserve": "npm run build",
     "serve": "http-server dist",
     "test": "npm run build",
-    "uglify:css": "uglify -s ./dist/bsi.css -o ./dist/bsi.min.css -c",
-    "uglify:js": "uglify -s ./dist/bsi.js -o ./dist/bsi.min.js"
+    "uglify:css": "cleancss -s ./dist/bsi.css -o ./dist/bsi.min.css -c",
+    "uglify:js": "uglifyjs ./dist/bsi.js --compress --mangle -o ./dist/bsi.min.js"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
   "devDependencies": {
     "autoprefixer": "^5.2.0",
     "browserify": "^11.2.0",
+    "clean-css": "^3.4.9",
     "cpy": "^3.4.0",
     "d2l-intl": "^0.2.1",
     "eslint": "^1.6.0",
@@ -49,7 +50,7 @@
     "node-sass": "^3.3.2",
     "postcss-cli": "^2.1.0",
     "rimraf": "^2.4.2",
-    "uglify": "^0.1.5",
+    "uglify-js": "^2.6.1",
     "uglifyify": "^3.0.1"
   }
 }


### PR DESCRIPTION
The npm project Uglify on windows throws errors when trying to minify css. Updated project to use the vastly more popular clean-css and uglify-js projects for minifying js and css code. 