### PR TITLE
Add overriding styles for dialogs.

### DIFF
--- a/src/bsi.scss
+++ b/src/bsi.scss
@@ -8,3 +8,4 @@
 @import 'floating-container.scss';
 @import 'html-block.scss';
 @import 'text-image-link.scss';
+@import 'dialog.scss';

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -1,0 +1,14 @@
+@import '../bower_components/vui-typography/typography.scss';
+
+.dbd_dialog .d2l-dialog-title .d2l-heading .vui-heading-1 {
+	color: $vui-fontColor;
+	font-size: 1em;
+	font-weight: inherit;
+	line-height: inherit;
+}
+
+.ddial_t a,
+.ddial_t a:hover,
+.ddial_t a:focus {
+	color: $vui-fontColor;
+}


### PR DESCRIPTION
These styles are currently hard-coded into the LMS (referencing #353535). The plan is to later remove those styles from the LMS, which would fall back to these (identical) styles. This will then give us a good spot to update the styles for C12.