### PR TITLE
Add bsi.html (with placeholder).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "vui-icons": "~1.1.0",
     "vui-input": "~1.5.5",
     "vui-link": "~1.1.1",
-	"vui-loading-spinner":"~1.0.0",
+    "vui-loading-spinner":"~1.0.0",
     "vui-image-action": "~0.2.1",
     "vui-list": "~1.0.1",
     "vui-offscreen": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "scripts": {
     "autoprefix": "postcss -c postcss.config.json",
     "prebuild": "rimraf dist && mkdir dist",
-    "build": "npm run build:js && npm run build:sass && npm run build:icons",
+    "build": "npm run build:js && npm run build:sass && npm run build:icons && npm run build:wc",
     "build:js": "browserify -g uglifyify ./src/index.js > ./dist/bsi.js",
     "postbuild:js": "npm run uglify:js",
     "build:sass": "node-sass --output-style expanded ./src/bsi.scss ./dist/bsi.css",
     "postbuild:sass": "npm run autoprefix && npm run uglify:css",
     "build:icons": "cpy ./bower_components/vui-icons/images/**/*.* ./dist/images",
+    "build:wc": "vulcanize ./src/bsi.html > ./dist/bsi.html",
     "postinstall": "./node_modules/.bin/bower install",
     "publish:cdn": "frau-publisher -m lib -t bsi -f './dist/**/*' -k AKIAIZGPQIRSA2WEJEDA --secretvar CDN_SECRET --versionvar TRAVIS_TAG",
     "preserve": "npm run build",
-    "serve": "http-server dist",
+    "serve": "http-server dist --cors",
     "test": "npm run build",
     "uglify:css": "cleancss -s ./dist/bsi.css -o ./dist/bsi.min.css -c",
     "uglify:js": "uglifyjs ./dist/bsi.js --compress --mangle -o ./dist/bsi.min.js"
-
   },
   "repository": {
     "type": "git",
@@ -52,6 +52,7 @@
     "postcss-cli": "^2.1.0",
     "rimraf": "^2.4.2",
     "uglify-js": "^2.6.1",
-    "uglifyify": "^3.0.1"
+    "uglifyify": "^3.0.1",
+    "vulcanize": "^1.14.7"
   }
 }

--- a/src/bsi.html
+++ b/src/bsi.html
@@ -1,0 +1,3 @@
+<script>
+  document.body.removeAttribute('unresolved');
+</script>


### PR DESCRIPTION
This PR adds `bsi.html` and `vulcanize` build step.  Eventually the `unresolved` JS will be replaced once we are including components.

@dlockhart : be awesome if you could take look.