### PR TITLE
Add note about trailing slash to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To point your Brightspace instance at the local integration project:
 
 1. Go to your `{instance}/config/Infrastructure` directory
 2. Edit `D2L.LP.Web.UI.Bsi.config.json`
-3. Change the `baseLocation` property to `http://localhost:8080` (or your computer's hostname)
+3. Change the `baseLocation` property to `http://localhost:8080/` (or your computer's hostname) - note the trailing `/`
 4. Restart IIS
 
 The config file will get overwritten during the build.


### PR DESCRIPTION
Itty bitty PR. Omitting the trailing slash causes things to not work, which is less than ideal.