### PR TITLE
US71024: Transplant HtmlBlock styles to BSI.

### DIFF
--- a/src/html-block.scss
+++ b/src/html-block.scss
@@ -1,6 +1,51 @@
 @import 'node_modules/vui-colors/colors.scss';
 
 .d2l-htmlblock {
+	line-height: normal;
+	text-align: left;
+	overflow-x: auto;
+	overflow-y: hidden;
+
+	& ul,
+	& ol {
+		list-style-position: outside;
+		margin: 1em 0;
+		padding-left: 3em;
+	}
+
+	& ul,
+	& ul[type="disc"] {
+		list-style-type: disc;
+	}
+
+	& ul ul,
+	& ul ol,
+	& ol ul,
+	& ol ol {
+		margin-top: 0;
+		margin-bottom:0;
+	}
+
+	& ul ul,
+	& ol ul,
+	& ul[type="circle"] {
+		list-style-type: circle;
+	}
+
+	& ul ul ul,
+	& ul ol ul,
+	& ol ul ul,
+	& ol ol ul,
+	& ul[type="square"] {
+		list-style-type: square;
+	}
+
+	& h1, & h2, & h3, & h4, & h5, & h6,
+	& b, & strong, & b *, & strong * {
+		font-weight: bold;
+	}
+
+
 	& a,
 	& a:visited {
 		color: $vui-color-celestine;
@@ -12,5 +57,61 @@
 	& a:focus {
 		color: $vui-color-celestuba;
 		text-decoration: underline;
+	}
+
+	& h1 {
+		font-size: 2em;
+		line-height: 37px;
+		margin: 21.43px 0;
+	}
+
+	& h2 {
+		font-size: 1.5em;
+		line-height: 27px;
+		margin: 19.92px 0;
+	}
+
+	& h3 {
+		font-size: 1.2em;
+		line-height: 23px;
+		margin: 18.72px 0;
+	}
+
+	& h4 {
+		font-size: 1em;
+		line-height: 20px;
+		margin: 21.28px 0;
+	}
+
+	& h5 {
+		font-size: 0.83em;
+		line-height: 16px;
+		margin: 22.13px 0;
+	}
+
+	& h6 {
+		font-size: 0.67em;
+		line-height: 13px;
+		margin: 24.97px 0;
+	}
+
+	& pre {
+		font-family: Monospace;
+		font-size: 13px;
+		margin: 13px 0;
+	}
+
+	& p {
+		margin: 0.5em 0 1em 0;
+	}
+}
+
+[dir='rtl'] .d2l-htmlblock {
+	text-align: right;
+
+	& ul,
+	& ol {
+		padding-left: 0em;
+		padding-right: 3em;
 	}
 }


### PR DESCRIPTION
These styles are copied from LP/framework/web/D2L.LP.Web.UI/Common/Controls/HtmlBlock/HtmlBlock.css
A corresponding PR will remove that file from the monolith.