### PR TITLE
Us70869 page padding on smaller viewports

### DIFF
--- a/src/page.scss
+++ b/src/page.scss
@@ -50,7 +50,7 @@
 
 	@media screen and (max-width: 25em)  {
     padding-left: 0.75rem;
-		padding-right: 0.75rem;
+    padding-right: 0.75rem;
   }
 }
 

--- a/src/page.scss
+++ b/src/page.scss
@@ -47,9 +47,13 @@
 
 .d2l-page-main-padding {
 	padding: 10px 1.5rem;
+
+	@media screen and (max-width: 25em)  {
+    padding-left: 0.75rem;
+		padding-right: 0.75rem;
+  }
 }
 
 .d2l-page-header {
 	margin-bottom: 1.5rem;
 }
-


### PR DESCRIPTION
This is a result of work on the announcements page to make it look better on mobile.  We found the padding to be a bit excessive on smaller screens.

I'm using EMs here which I personally like for media queries but I could also change it to px if that's what is preferred.

Jeff and I discussed this and would like to further improve it in the not too distant future, to work with our overall grid design - but this is still helpful now.

@dlockhart 