### PR TITLE
not including all the VUI icons CSS classnames

### DIFF
--- a/src/icons.scss
+++ b/src/icons.scss
@@ -1,0 +1,35 @@
+@import '../bower_components/d2l-icons/icons.scss';
+
+[class*=" d2l-icon-"],
+[class^="d2l-icon-"],
+[class*=" vui-icon-"],
+[class^="vui-icon-"] {
+	@include d2l-icon();
+}
+
+/* these legacy vui-icon-* icons are still needed for a few FRAs that are referencing them */
+
+/* awards-ui */
+.vui-icon-delete:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAJFBMVEX///9mZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmahSWycAAAAC3RSTlMAGDk/RU7A2+Tn7SFQNKgAAABCSURBVAjXY2BgYF29K4ABBDgMmBtAdPZuINgGZOwGAwYkwA0S2IDKkN4IZXBvIIGhvQnM4ASZMwHIYKnevXu7AwMA4HctSyhgF2EAAAAASUVORK5CYII=");
+}
+/* awards-ui, nitro-ui */
+.vui-icon-edit:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAe1BMVEX///9XMhNYNBJdMxSKioqOdWWPcmOpRBWpqamzXCu0ZDO4bSW+cybBRhTCfTDHZjPIW2DIlmbPgknZcTrcrmzdcnfhwq/kly7mmVzqlxXswqjy2cjy3L30pKf1wF/1wKX3vL/3ycz4y8z448L5zM752sv62o3639H85rJ1vFtFAAAAAXRSTlMAQObYZgAAAGVJREFUGNN9zzcWgDAMA9AANpheTe/9/idk4AHJgravSRLiJ8wcyQaeZrkhgnUd+XUBRNB9RbGcQASy+wqIFO8lPPZup4/dVjXmsermcIIsCd8BuG2Db9nfQt0c6lqy0AxE/Ll8AVC1B/ruPUdBAAAAAElFTkSuQmCC");
+}
+/* awards-ui */
+.vui-icon-file-pdf-xlarge:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAABKVBMVEX///+nrrVkAACZmZmenp6fn5+kpKSmpqanrrWpqamqqqqsLi+srKyuMzOurq6vr6+wODiwsLCxPT2xsbGzQkKzs7O0tLS1Rka3S0u4uLi5ubm6urq7u7u9vb2+vr6/v7/AwMDBwcHDw8PExMTFxcXGxsbHc3PIyMjJycnKysrLy8vMzMzNzc3Pzs7Pz8/Q0tXR0dHR1NbS0tLS1NfT1djU1tnV19rV2NvW1tbX19fX2dzX2tzZ2dna2trb29vd3d3e3t7f39/h4eHi4uLj4+Pk5OTo6Ojp6enq6urr6urr6+vs7Ozt7O3t7e3u7e3u7u7v7u7v7+/w7+/w8PDx8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3///9pJNgiAAAAAnRSTlMAnxYjQ+0AAAHESURBVEjHpdT9d5JQGMDxsQcUl+lssZprsc2RLnpZtVarlTo3LRCREeB8Sd3//0ckpsQzduHe9v3lPlzO55x7gMPKyn8mxsQRyA05ghF75MSvHDPxvnCsxHU/cRREfVYNiG3bJ1wygfeFgFizPkaM6OGqMPy8nEXD75hLJF45IPq8D1wSaSgB+fm3d1wsaYHyj7QWvUVm9iBRPVhTljPh27lN3CyobjQxTJxb7UPNiRZLzuA7K9mFA1aSAiGJ2LhvoMKhHSmObIMj8xoL0aDoGMImCzmAc9s9ih4NEQvFpz3L6stQwtsWmbyBU38ZyZC/JJNuuFT6er42i8DnMwCQ33w930DEDFWCC9OsVXI8ZCUZIHtWV5V0xb9DIi1eajxPbbys6zeT8W9XSUNWrdYP40gJ1vYa0/HAc/wrezjV1aK0Y0VIJ+gC5MnA7YT61R+Nh11/QsRYVJYkwTVI3UGaObkKRyYDaWZkj5euDTrS9stIw5zQa5NDxP9TvRLMLUEzdHIRsiMVhNqVTku0WT9KiuNocUWI2e+bGhtJ7p5klbIweUEVIk+pQuQJVYg8pgqRR1Qhsk4VIg+pQuQBVav3e5VM/QGQKaKq8GBlvwAAAABJRU5ErkJggg==");
+}
+/* awards-ui, awards-service, nitroui */
+.vui-icon-remove:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAgMAAABinRfyAAAACVBMVEX///98fHy9vb02RwSKAAAAAXRSTlMAQObYZgAAADZJREFUCB0FwTENACAMALCOhAMDOMDHJOzkRAoiEEwLABC3pTgj2QvzoRfGwdp4k1b9iowEAHzpNgXTV0Ym1gAAAABJRU5ErkJggg==");
+}
+/* nitro-ui */
+.vui-icon-search:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAYFBMVEUBd5X///8Bd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5UBd5X3IYA/AAAAH3RSTlMAAAMGCQwVGC0/RUhOcnV7foS9wMbMz9XY297h5Pn8LM3gRAAAAG5JREFUGNNtz1kOgCAMRdEKzrOi4vz2v0txKFHi/WpOmlDIcyKPPl0gin7vC2FBKJwpwVBhzWW+omKYkZopwcywITCTxOZuTAwNloyyBTWD312vQEf2jnLAWI/Q4QN3kT7lfbqR9gMUqpj+Pud0ANdXBsZbuN4oAAAAAElFTkSuQmCC");
+}
+/* awards-ui */
+.vui-icon-share:before {
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAMFBMVEX///9mZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmambAcKAAAAD3RSTlMAAwZdYISHio2Q2Nvk5+plfijHAAAAWElEQVQI12NgAAHVM0FgmiH//zcI4/3/f2Ca+T+EIbL+///vQHVT1v/2vNsEVPf/lyNE3X9HqIb/BlAjoFIad6fs/+UBMRmkHWKyCNRAhBVAHd8hDI27TQDcrDIUgsuADAAAAABJRU5ErkJggg==");
+}

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -1,5 +1,5 @@
 @import '../bower_components/vui-focus/focus.css.scss';
-@import '../bower_components/d2l-icons/icons.css.scss';
+@import 'icons.scss';
 @import '../bower_components/jquery-vui-accordion/accordion.css.scss';
 @import '../node_modules/vui-breadcrumbs/breadcrumbs.css.scss';
 @import '../node_modules/vui-button/button.css.scss';


### PR DESCRIPTION
@dbatiste, @njostonehouse, @capajon 

With the new Daylight icons, the size of `bsi.min.css` has gotten out of control:
- before Daylight icons: 137Kb
- with Daylight icons: 335Kb
- with no icons as all (after this PR): 92Kb

As you can see, the main problem is that we're including the CSS to use each icon as a background image by class-name. The monolith only uses those class names in a couple places, and even then has a way to fall back. So I'd like to remove this altogether with Daylight.

Corresponding PR in ILP:
https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/2660/overview

A few UMD-based FRAs [are referencing these class names](http://search.dev.d2l/source/search?q=%22vui-icon%22&defs=&refs=&path=&hist=&type=&project=LSOne), and I've reached out to them to try and get them to switch over to the mixins. In the meantime, I've manually embedded the ones they need.