### PR TITLE
VUI to D2L 1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.5.0",
     "vui-button": "~2.1.4",
+    "vui-field": "~1.2.0",
     "vui-focus": "~0.7.1",
     "vui-link": "~2.1.0",
     "vui-loading-spinner": "~1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -2,9 +2,9 @@
   "name": "brightspace-integration",
   "dependencies": {
     "d2l-colors": "~2.0.0",
-    "d2l-icons": "~2.0.2",
+    "d2l-icons": "~2.1.0",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
-    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.0",
+    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.1",
     "d2l-offscreen": "~2.0.0",
     "jquery-vui-accordion": "~0.3.0",
     "jquery-vui-collapsible-section": "~1.2.0",

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "d2l-colors": "~2.0.0",
     "d2l-icons": "~2.1.0",
+    "d2l-link": "~3.0.0",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.1",
     "d2l-offscreen": "~2.0.0",
@@ -15,7 +16,6 @@
     "vui-button": "~2.1.4",
     "vui-field": "~1.2.0",
     "vui-focus": "~0.7.1",
-    "vui-link": "~2.1.0",
     "vui-loading-spinner": "~1.0.0"
   },
   "private": true

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.1",
     "d2l-offscreen": "~2.0.0",
+    "d2l-typography": "~4.0.0",
     "jquery-vui-accordion": "~0.3.0",
     "jquery-vui-collapsible-section": "~1.2.0",
     "jquery-vui-change-tracking": "~0.4.0",
@@ -15,8 +16,7 @@
     "vui-field": "~1.2.0",
     "vui-focus": "~0.7.1",
     "vui-link": "~2.1.0",
-    "vui-loading-spinner": "~1.0.0",
-    "vui-typography": "~3.1.0"
+    "vui-loading-spinner": "~1.0.0"
   },
   "private": true
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "brightspace-integration",
   "dependencies": {
+    "d2l-colors": "~2.0.0",
     "d2l-icons": "~2.0.2",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.3.6",
@@ -11,7 +12,6 @@
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.4.0",
     "vui-button": "~2.1.4",
-    "vui-colors": "~1.0.1",
     "vui-focus": "~0.7.1",
     "vui-link": "~2.1.0",
     "vui-loading-spinner": "~1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "jquery-vui-change-tracking": "~0.4.0",
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.5.0",
+    "vui-breadcrumbs": "~2.1.0",
     "vui-field": "~1.2.0",
     "vui-focus": "~0.7.1",
     "vui-loading-spinner": "~1.0.0"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "d2l-colors": "~2.0.0",
     "d2l-icons": "~2.1.0",
     "d2l-link": "~3.0.0",
-    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
+    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.1",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.1",
     "d2l-offscreen": "~2.0.0",
     "d2l-typography": "~4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "brightspace-integration",
   "dependencies": {
+    "d2l-button": "~3.0.0",
     "d2l-colors": "~2.0.0",
     "d2l-icons": "~2.1.0",
     "d2l-link": "~3.0.0",
@@ -13,7 +14,6 @@
     "jquery-vui-change-tracking": "~0.4.0",
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.5.0",
-    "vui-button": "~2.1.4",
     "vui-field": "~1.2.0",
     "vui-focus": "~0.7.1",
     "vui-loading-spinner": "~1.0.0"

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "jquery-vui-collapsible-section": "~1.2.0",
     "jquery-vui-change-tracking": "~0.4.0",
     "jquery-vui-scrollspy": "~0.2.0",
-    "polymer": "^1.4.0",
+    "polymer": "^1.5.0",
     "vui-button": "~2.1.4",
     "vui-focus": "~0.7.1",
     "vui-link": "~2.1.0",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "d2l-colors": "~2.0.0",
     "d2l-icons": "~2.0.2",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.4.0",
-    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.3.6",
+    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.4.0",
     "d2l-offscreen": "~2.0.0",
     "jquery-vui-accordion": "~0.3.0",
     "jquery-vui-collapsible-section": "~1.2.0",

--- a/bsi-style.html
+++ b/bsi-style.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-typography/d2l-typography.html">
-<link rel="import" href="../vui-link/link.html">
 <link rel="import" href="htmleditor.html">
 
 <link rel="import" href="button.html">

--- a/bsi-style.html
+++ b/bsi-style.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../vui-typography/typography.html">
+<link rel="import" href="../d2l-typography/d2l-typography.html">
 <link rel="import" href="../vui-link/link.html">
 <link rel="import" href="htmleditor.html">
 
@@ -13,7 +13,7 @@
 
 <dom-module id="bsi-style">
 	<template>
-		<style include="vui-typography"></style>
+		<style include="d2l-typography"></style>
 		<style include="bsi-button"></style>
 		<style include="bsi-button-menu"></style>
 		<style include="bsi-button-split"></style>

--- a/bsi-style.html
+++ b/bsi-style.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-typography/d2l-typography.html">
+<link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="htmleditor.html">
 
 <link rel="import" href="button.html">

--- a/bsi.html
+++ b/bsi.html
@@ -1,5 +1,5 @@
 <link rel="import" href="bsi-style.html">
-<link rel="import" href="../vui-button/button.html">
-<link rel="import" href="../vui-button/floating-buttons.html">
+<link rel="import" href="../d2l-button/d2l-button.html">
+<link rel="import" href="../d2l-button/d2l-floating-buttons.html">
 <link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="../d2l-navigation/navigation.html">

--- a/bsi.html
+++ b/bsi.html
@@ -1,5 +1,4 @@
 <link rel="import" href="bsi-style.html">
 <link rel="import" href="../d2l-button/d2l-button.html">
 <link rel="import" href="../d2l-button/d2l-floating-buttons.html">
-<link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="../d2l-navigation/navigation.html">

--- a/bsi.html
+++ b/bsi.html
@@ -1,4 +1,5 @@
 <link rel="import" href="bsi-style.html">
 <link rel="import" href="../vui-button/button.html">
 <link rel="import" href="../vui-button/floating-buttons.html">
+<link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="../d2l-navigation/navigation.html">

--- a/button-menu.html
+++ b/button-menu.html
@@ -1,9 +1,8 @@
-<link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../vui-button/button-style.html">
 <dom-module id="bsi-button-menu">
 	<template>
-		<style include="vui-colors"></style>
-		<style include="vui-button-style">
+		<style include="d2l-colors vui-button-style">
 
 			.bsi-button-menu {
 				border-width: 1px;
@@ -40,13 +39,13 @@
 			.bsi-button-menu,
 			.bsi-button-menu[disabled]:hover,
 			.bsi-button-menu[disabled]:focus {
-				background-color: var(--vui-color-woolonardo);
-				border-color: var(--vui-color-titanius);
-				color: var(--vui-color-ferrite);
+				background-color: var(--d2l-color-woolonardo);
+				border-color: var(--d2l-color-titanius);
+				color: var(--d2l-color-ferrite);
 			}
 
 			.bsi-button-menu:hover, .bsi-button-menu:focus {
-				background-color: var(--vui-color-gypsum);
+				background-color: var(--d2l-color-gypsum);
 			}
 
 			.bsi-button-menu[disabled] {
@@ -57,13 +56,13 @@
 			.bsi-button-menu.bsi-button-menu-primary,
 			.bsi-button-menu.bsi-button-menu-primary[disabled]:hover,
 			.bsi-button-menu.bsi-button-menu-primary[disabled]:focus {
-				background-color: var(--vui-color-celestine);
-				border-color: var(--vui-color-celestuba);
-				color: var(--vui-color-white);
+				background-color: var(--d2l-color-celestine);
+				border-color: var(--d2l-color-celestuba);
+				color: var(--d2l-color-white);
 			}
 			.bsi-button-menu.bsi-button-menu-primary:hover,
 			.bsi-button-menu.bsi-button-menu-primary:focus {
-				background-color: var(--vui-color-celestuba);
+				background-color: var(--d2l-color-celestuba);
 			}
 
 		</style>

--- a/button-menu.html
+++ b/button-menu.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../vui-button/button-style.html">
+<link rel="import" href="../d2l-button/d2l-button-shared-styles.html">
 <dom-module id="bsi-button-menu">
 	<template>
-		<style include="d2l-colors vui-button-style">
+		<style include="d2l-colors d2l-button-shared-styles">
 
 			.bsi-button-menu {
 				border-width: 1px;
@@ -16,7 +16,7 @@
 				font-weight: 700;
 				letter-spacing: 0.02rem;
 				line-height: 1rem;
-				margin: 0 var(--vui-button-spacing) 0 0;
+				margin: 0 var(--d2l-button-spacing) 0 0;
 				min-height: -webkit-calc(2rem + 2px);
 				min-height: calc(2rem + 2px);
 				outline: none;
@@ -32,13 +32,13 @@
 			}
 
 			[dir='rtl'] .bsi-button-menu {
-				margin-left: var(--vui-button-spacing);
+				margin-left: var(--d2l-button-spacing);
 				margin-right: 0;
 			}
 
 			.bsi-button-menu,
-			.bsi-button-menu[disabled]:hover,
-			.bsi-button-menu[disabled]:focus {
+			.bsi-button-menu.vui-disabled:hover,
+			.bsi-button-menu.vui-disabled:focus {
 				background-color: var(--d2l-color-woolonardo);
 				border-color: var(--d2l-color-titanius);
 				color: var(--d2l-color-ferrite);
@@ -48,14 +48,14 @@
 				background-color: var(--d2l-color-gypsum);
 			}
 
-			.bsi-button-menu[disabled] {
+			.bsi-button-menu.vui-disabled {
 				opacity: 0.5;
 				cursor: default;
 			}
 
 			.bsi-button-menu.bsi-button-menu-primary,
-			.bsi-button-menu.bsi-button-menu-primary[disabled]:hover,
-			.bsi-button-menu.bsi-button-menu-primary[disabled]:focus {
+			.bsi-button-menu.bsi-button-menu-primary.vui-disabled:hover,
+			.bsi-button-menu.bsi-button-menu-primary.vui-disabled:focus {
 				background-color: var(--d2l-color-celestine);
 				border-color: var(--d2l-color-celestuba);
 				color: var(--d2l-color-white);

--- a/button-split.html
+++ b/button-split.html
@@ -1,7 +1,7 @@
-<link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 <dom-module id="bsi-button-split">
 	<template>
-		<style include="vui-colors">
+		<style include="d2l-colors">
 
 			.d2l-button-split > button {
 				border-top-right-radius: 0;
@@ -35,7 +35,7 @@
 			}
 
 			[dir='rtl'] .d2l-button-split > .d2l-button-menu {
-				border-left-color: var(--vui-color-titanius);
+				border-left-color: var(--d2l-color-titanius);
 				border-right-color: transparent;
 				border-top-left-radius: 0.3rem;
 				border-bottom-left-radius: 0.3rem;
@@ -45,7 +45,7 @@
 
 			[dir='rtl'] .d2l-button-split > .d2l-button-menu:hover,
 			[dir='rtl'] .d2l-button-split > .d2l-button-menu:focus {
-				border-color: var(--vui-color-pressicus);
+				border-color: var(--d2l-color-pressicus);
 			}
 
 		</style>

--- a/button.html
+++ b/button.html
@@ -1,13 +1,13 @@
-<link rel="import" href="../vui-button/button-style.html">
+<link rel="import" href="../d2l-button/d2l-button-shared-styles.html">
 <dom-module id="bsi-button">
 	<template>
-		<style include="vui-button-style">
+		<style include="d2l-button-shared-styles">
 
 			.d2l-button {
-				margin-right: var(--vui-button-spacing);
+				margin-right: var(--d2l-button-spacing);
 			}
 			[dir='rtl'] .d2l-button {
-				margin-left: var(--vui-button-spacing);
+				margin-left: var(--d2l-button-spacing);
 				margin-right: 0;
 			}
 

--- a/collapse-pane.html
+++ b/collapse-pane.html
@@ -16,7 +16,7 @@
 				text-decoration: underline;
 			}
 
-			.vui-typography .d2l-collapsepane-header .d2l-heading {
+			.d2l-typography .d2l-collapsepane-header .d2l-heading {
 				margin: 0;
 				padding-bottom: 0;
 			}

--- a/collapse-pane.html
+++ b/collapse-pane.html
@@ -1,10 +1,10 @@
-<link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 <dom-module id="bsi-collapse-pane">
 	<template>
-		<style include="vui-colors">
+		<style include="d2l-colors">
 
 			.d2l-collapsepane-action > .d2l-heading {
-				color: var(--vui-color-celestine);
+				color: var(--d2l-color-celestine);
 				cursor: pointer;
 				font-weight: normal;
 				text-decoration: none;
@@ -12,7 +12,7 @@
 
 			.d2l-collapsepane-action:hover > .d2l-heading,
 			.d2l-collapsepane-action:focus > .d2l-heading {
-				color: var(--vui-color-celestuba);
+				color: var(--d2l-color-celestuba);
 				text-decoration: underline;
 			}
 

--- a/headings.html
+++ b/headings.html
@@ -5,7 +5,11 @@
 			.d2l-typography .d2l-heading-1,
 			.d2l-typography .d2l-heading-2,
 			.d2l-typography .d2l-heading-3,
-			.d2l-typography .d2l-heading-4 {
+			.d2l-typography .d2l-heading-4,
+			.vui-typography .vui-heading-1,
+			.vui-typography .vui-heading-2,
+			.vui-typography .vui-heading-3,
+			.vui-typography .vui-heading-4 {
 				margin-top: 0;
 				margin-bottom: 0;
 				margin-right: 6px;
@@ -14,18 +18,26 @@
 			[dir='rtl'] .d2l-typography .d2l-heading-1,
 			[dir='rtl'] .d2l-typography .d2l-heading-2,
 			[dir='rtl'] .d2l-typography .d2l-heading-3,
-			[dir='rtl'] .d2l-typography .d2l-heading-4 {
+			[dir='rtl'] .d2l-typography .d2l-heading-4,
+			[dir='rtl'] .vui-typography .vui-heading-1,
+			[dir='rtl'] .vui-typography .vui-heading-2,
+			[dir='rtl'] .vui-typography .vui-heading-3,
+			[dir='rtl'] .vui-typography .vui-heading-4 {
 				margin-right: 0;
 				margin-left: 6px;
 			}
 
 			.d2l-typography .d2l-heading-1,
-			.d2l-typography .d2l-heading-2 {
+			.d2l-typography .d2l-heading-2,
+			.vui-typography .vui-heading-1,
+			.vui-typography .vui-heading-2 {
 				padding-bottom: 15px;
 			}
 
 			.d2l-typography .d2l-heading-1.d2l-heading-half,
-			.d2l-typography .d2l-heading-2.d2l-heading-half {
+			.d2l-typography .d2l-heading-2.d2l-heading-half,
+			.vui-typography .vui-heading-1.d2l-heading-half,
+			.vui-typography .vui-heading-2.d2l-heading-half {
 				padding: 0;
 				margin: 0;
 				padding-bottom: 8px;

--- a/headings.html
+++ b/headings.html
@@ -2,36 +2,36 @@
 	<template>
 		<style>
 
-			.vui-typography .vui-heading-1,
-			.vui-typography .vui-heading-2,
-			.vui-typography .vui-heading-3,
-			.vui-typography .vui-heading-4 {
+			.d2l-typography .d2l-heading-1,
+			.d2l-typography .d2l-heading-2,
+			.d2l-typography .d2l-heading-3,
+			.d2l-typography .d2l-heading-4 {
 				margin-top: 0;
 				margin-bottom: 0;
 				margin-right: 6px;
 			}
 
-			[dir='rtl'] .vui-typography .vui-heading-1,
-			[dir='rtl'] .vui-typography .vui-heading-2,
-			[dir='rtl'] .vui-typography .vui-heading-3,
-			[dir='rtl'] .vui-typography .vui-heading-4 {
+			[dir='rtl'] .d2l-typography .d2l-heading-1,
+			[dir='rtl'] .d2l-typography .d2l-heading-2,
+			[dir='rtl'] .d2l-typography .d2l-heading-3,
+			[dir='rtl'] .d2l-typography .d2l-heading-4 {
 				margin-right: 0;
 				margin-left: 6px;
 			}
 
-			.vui-typography .vui-heading-1,
-			.vui-typography .vui-heading-2 {
+			.d2l-typography .d2l-heading-1,
+			.d2l-typography .d2l-heading-2 {
 				padding-bottom: 15px;
 			}
 
-			.vui-typography .vui-heading-1.d2l-heading-half,
-			.vui-typography .vui-heading-2.d2l-heading-half {
+			.d2l-typography .d2l-heading-1.d2l-heading-half,
+			.d2l-typography .d2l-heading-2.d2l-heading-half {
 				padding: 0;
 				margin: 0;
 				padding-bottom: 8px;
 			}
 
-			.vui-typography .bsi-set-solid {
+			.d2l-typography .bsi-set-solid {
 				line-height: 100%;
 				margin: 0;
 				padding: 0;

--- a/htmlblock.html
+++ b/htmlblock.html
@@ -1,6 +1,7 @@
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 <dom-module id="bsi-htmlblock">
 	<template>
-		<style include="vui-colors">
+		<style include="d2l-colors">
 			.vui-typography .d2l-htmlblock {
 				line-height: normal;
 				text-align: left;
@@ -103,7 +104,7 @@
 
 			.d2l-htmlblock a,
 			.d2l-htmlblock a:visited {
-				color: var(--vui-color-celestine);
+				color: var(--d2l-color-celestine);
 				cursor: pointer;
 				font-weight: normal;
 				text-decoration: none;
@@ -111,7 +112,7 @@
 
 			.d2l-htmlblock a:hover,
 			.d2l-htmlblock a:focus {
-				color: var(--vui-color-celestuba);
+				color: var(--d2l-color-celestuba);
 				text-decoration: underline;
 			}
 

--- a/htmlblock.html
+++ b/htmlblock.html
@@ -2,69 +2,69 @@
 <dom-module id="bsi-htmlblock">
 	<template>
 		<style include="d2l-colors">
-			.vui-typography .d2l-htmlblock {
+			.d2l-typography .d2l-htmlblock {
 				line-height: normal;
 				text-align: left;
 				overflow-x: auto;
 				overflow-y: hidden;
 			}
 
-			.vui-typography .d2l-htmlblock h1,
-			.vui-typography .d2l-htmlblock h2,
-			.vui-typography .d2l-htmlblock h3,
-			.vui-typography .d2l-htmlblock h4,
-			.vui-typography .d2l-htmlblock h5,
-			.vui-typography .d2l-htmlblock h6,
-			.vui-typography .d2l-htmlblock b,
-			.vui-typography .d2l-htmlblock strong,
-			.vui-typography .d2l-htmlblock b *,
-			.vui-typography .d2l-htmlblock strong * {
+			.d2l-typography .d2l-htmlblock h1,
+			.d2l-typography .d2l-htmlblock h2,
+			.d2l-typography .d2l-htmlblock h3,
+			.d2l-typography .d2l-htmlblock h4,
+			.d2l-typography .d2l-htmlblock h5,
+			.d2l-typography .d2l-htmlblock h6,
+			.d2l-typography .d2l-htmlblock b,
+			.d2l-typography .d2l-htmlblock strong,
+			.d2l-typography .d2l-htmlblock b *,
+			.d2l-typography .d2l-htmlblock strong * {
 				font-weight: bold;
 			}
 
-			.vui-typography .d2l-htmlblock h1 {
+			.d2l-typography .d2l-htmlblock h1 {
 				font-size: 2em;
 				line-height: 37px;
 				margin: 21.43px 0;
 			}
 
-			.vui-typography .d2l-htmlblock h2 {
+			.d2l-typography .d2l-htmlblock h2 {
 				font-size: 1.5em;
 				line-height: 27px;
 				margin: 19.92px 0;
 			}
 
-			.vui-typography .d2l-htmlblock  h3 {
+			.d2l-typography .d2l-htmlblock  h3 {
 				font-size: 1.2em;
 				line-height: 23px;
 				margin: 18.72px 0;
 			}
 
-			.vui-typography .d2l-htmlblock  h4 {
+			.d2l-typography .d2l-htmlblock  h4 {
 				font-size: 1em;
 				line-height: 20px;
 				margin: 21.28px 0;
 			}
 
-			.vui-typography .d2l-htmlblock h5 {
+			.d2l-typography .d2l-htmlblock h5 {
 				font-size: 0.83em;
 				line-height: 16px;
 				margin: 22.13px 0;
 			}
 
-			.vui-typography .d2l-htmlblock  h6 {
+			.d2l-typography .d2l-htmlblock  h6 {
 				font-size: 0.67em;
 				line-height: 13px;
 				margin: 24.97px 0;
 			}
 
-			.vui-typography .d2l-htmlblock pre {
+			.d2l-typography .d2l-htmlblock pre {
 				font-family: Monospace;
 				font-size: 13px;
 				margin: 13px 0;
 			}
 
-			.vui-typography .d2l-htmlblock p {
+			.d2l-typography .d2l-htmlblock p {
 				margin: 0.5em 0 1em 0;
 			}
 

--- a/htmleditor.html
+++ b/htmleditor.html
@@ -1,9 +1,9 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 
 <dom-module id="bsi-htmleditor">
 	<template>
-		<style>
+		<style include="d2l-colors">
 			:root {
 				--vui-htmleditor-icon-height: 16px;
 				--vui-htmleditor-toolbar-height: 2rem;
@@ -48,7 +48,7 @@
 
 			.d2l-htmleditor-component-toggle:hover,
 			.d2l-htmleditor-component-toggle:focus {
-				background-color: var(--vui-color-woolonardo);
+				background-color: var(--d2l-color-woolonardo);
 			}
 
 			.d2l-htmleditor-component-container {
@@ -126,7 +126,7 @@
 
 			.d2l-menuflyout.d2l-htmleditor-menuflyout .d2l-menuflyout-opener:hover,
 			.d2l-menuflyout.d2l-htmleditor-menuflyout .d2l-menuflyout-opener:focus {
-				background: var(--vui-color-woolonardo);
+				background: var(--d2l-color-woolonardo);
 			}
 
 			.d2l-menuflyout.d2l-htmleditor-menuflyout > .d2l-menuflyout-contents {
@@ -155,7 +155,7 @@
 
 			.d2l-htmleditor-button:hover,
 			.d2l-htmleditor-button:focus {
-		    background-color: var(--vui-color-woolonardo);
+		    background-color: var(--d2l-color-woolonardo);
 			}
 
 			.d2l-htmleditor-buttonmenuitem {
@@ -204,7 +204,7 @@
 
 			.d2l-htmleditor-color-button:hover,
 			.d2l-htmleditor-color-button:focus {
-				background: var(--vui-color-woolonardo);
+				background: var(--d2l-color-woolonardo);
 			}
 
 		</style>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "uglifyify": "^3.0.1",
     "vui-breadcrumbs": "git://github.com/Brightspace/valence-ui-breadcrumbs.git#bsi-wc",
     "vui-button": "git://github.com/Brightspace/valence-ui-button.git#bsi-wc",
-    "vui-colors": "git://github.com/Brightspace/valence-ui-colors.git#sass",
     "vui-dropdown": "git://github.com/Brightspace/valence-ui-dropdown.git#bsi-wc",
     "vui-field": "git://github.com/Brightspace/valence-ui-field.git#bsi-wc",
     "vui-image-action": "git://github.com/Brightspace/valence-ui-image-action.git#bsi-wc",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "vui-link": "git://github.com/Brightspace/valence-ui-link.git#bsi-wc",
     "vui-list": "git://github.com/Brightspace/valence-ui-list.git#bsi-wc",
     "vui-table": "git://github.com/Brightspace/valence-ui-table.git#bsi-wc",
-    "vui-typography": "git://github.com/Brightspace/valence-ui-typography.git#bsi-wc",
     "vui-validation": "git://github.com/Brightspace/valence-ui-validation.git#bsi-wc",
     "web-component-shards": "^1.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "vui-dropdown": "git://github.com/Brightspace/valence-ui-dropdown.git#bsi-wc",
     "vui-image-action": "git://github.com/Brightspace/valence-ui-image-action.git#bsi-wc",
     "vui-input": "git://github.com/Brightspace/valence-ui-input.git#bsi-wc",
-    "vui-link": "git://github.com/Brightspace/valence-ui-link.git#bsi-wc",
     "vui-list": "git://github.com/Brightspace/valence-ui-list.git#bsi-wc",
     "vui-table": "git://github.com/Brightspace/valence-ui-table.git#bsi-wc",
     "vui-validation": "git://github.com/Brightspace/valence-ui-validation.git#bsi-wc",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "uglify-js": "^2.6.1",
     "uglifyify": "^3.0.1",
     "vui-breadcrumbs": "git://github.com/Brightspace/valence-ui-breadcrumbs.git#bsi-wc",
-    "vui-button": "git://github.com/Brightspace/valence-ui-button.git#bsi-wc",
     "vui-dropdown": "git://github.com/Brightspace/valence-ui-dropdown.git#bsi-wc",
     "vui-image-action": "git://github.com/Brightspace/valence-ui-image-action.git#bsi-wc",
     "vui-input": "git://github.com/Brightspace/valence-ui-input.git#bsi-wc",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "vui-breadcrumbs": "git://github.com/Brightspace/valence-ui-breadcrumbs.git#bsi-wc",
     "vui-button": "git://github.com/Brightspace/valence-ui-button.git#bsi-wc",
     "vui-dropdown": "git://github.com/Brightspace/valence-ui-dropdown.git#bsi-wc",
-    "vui-field": "git://github.com/Brightspace/valence-ui-field.git#bsi-wc",
     "vui-image-action": "git://github.com/Brightspace/valence-ui-image-action.git#bsi-wc",
     "vui-input": "git://github.com/Brightspace/valence-ui-input.git#bsi-wc",
     "vui-link": "git://github.com/Brightspace/valence-ui-link.git#bsi-wc",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "rimraf": "^2.4.2",
     "uglify-js": "^2.6.1",
     "uglifyify": "^3.0.1",
-    "vui-breadcrumbs": "git://github.com/Brightspace/valence-ui-breadcrumbs.git#bsi-wc",
     "vui-dropdown": "git://github.com/Brightspace/valence-ui-dropdown.git#bsi-wc",
     "vui-image-action": "git://github.com/Brightspace/valence-ui-image-action.git#bsi-wc",
     "vui-input": "git://github.com/Brightspace/valence-ui-input.git#bsi-wc",

--- a/src/container-icon-link.scss
+++ b/src/container-icon-link.scss
@@ -1,15 +1,15 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-container-icon-link {
 	& > a > .d2l-container-icon-link-link {
-		color: $vui-color-celestine;
+		color: $d2l-color-celestine;
 		cursor: pointer;
 		font-weight: normal;
 		text-decoration: none;
 	}
 	& > a:hover > .d2l-container-icon-link-link,
 	& > a:focus > .d2l-container-icon-link-link {
-		color: $vui-color-celestuba;
+		color: $d2l-color-celestuba;
 		text-decoration: underline;
 	}
 }

--- a/src/context-menu.scss
+++ b/src/context-menu.scss
@@ -1,5 +1,6 @@
 @import 'node_modules/vui-typography/px-to-base-rem.scss';
 @import 'node_modules/vui-dropdown/context-menu.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 @keyframes vui-dropdown-menu-overlay-flip-x-animation {
 	0% {
@@ -36,7 +37,7 @@
 .vui-dropdown-menu > ul > li.d2l-last-visible-item {
 	border-bottom-left-radius: 0.4rem;
 	border-bottom-right-radius: 0.4rem;
-	border-bottom: 1px solid $vui-color-titanius;
+	border-bottom: 1px solid $d2l-color-titanius;
 }
 
 .vui-dropdown-menu > ul > li.d2l-contextmenu-item-hover-next-visible {

--- a/src/context-menu.scss
+++ b/src/context-menu.scss
@@ -1,4 +1,3 @@
-@import 'node_modules/vui-typography/px-to-base-rem.scss';
 @import 'node_modules/vui-dropdown/context-menu.scss';
 @import '../bower_components/d2l-colors/d2l-colors.scss';
 
@@ -46,24 +45,24 @@
 
 .vui-dropdown-menu-item-link {
 	background-repeat: no-repeat;
-	background-position: px-to-base-rem(11px) px-to-base-rem(20px);
+	background-position: 0.55rem 1rem;
 	box-sizing: border-box;
-	padding-left: px-to-base-rem(42px);
+	padding-left: 2.1rem;
 }
 
 [dir='rtl'] .vui-dropdown-menu-item-link {
-	background-position: right px-to-base-rem(11px) top px-to-base-rem(20px);
-	padding-left: px-to-base-rem(11px);
-	padding-right: px-to-base-rem(42px);
+	background-position: right 0.55rem top 1rem;
+	padding-left: 0.55rem;
+	padding-right: 2.1rem;
 }
 
 .dcm.dcm_handle.bsi-button-menu,
 .d2l-contextmenu-ph {
 	@include vui-dropdown-context-menu;
-	margin-left: px-to-base-rem(5);
+	margin-left: 0.25rem;
 	[dir='rtl'] & {
 		margin-left: auto;
-		margin-right: px-to-base-rem(5);
+		margin-right: 0.25rem;
 	}
 }
 

--- a/src/deprecated/button.scss
+++ b/src/deprecated/button.scss
@@ -1,0 +1,90 @@
+@import '../../bower_components/d2l-colors/d2l-colors.scss';
+
+/* these are still referenced by a few FRAs, button-filter-groups, iterator */
+
+@mixin _vui-button(
+		$color,
+		$background,
+		$borderColor,
+		$hoverBackground,
+		$hoverBorderColor
+	) {
+
+	color: $color;
+	font-family: inherit;
+	font-size: 0.7rem;
+	font-weight: 700;
+	line-height: 1rem;
+	letter-spacing: 0.02rem;
+	margin: 0;
+	border-radius: 0.3rem;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: inline-block;
+	min-height: calc(2rem + 2px);
+	padding: 0.5rem 1.5rem;
+	text-align: center;
+	user-select: none;
+	vertical-align: middle;
+	white-space: nowrap;
+	width: auto;
+
+	&,
+	&:visited,
+	&:link,
+	&:hover,
+	&:focus,
+	&.vui-disabled:hover,
+	&.vui-disabled:focus,
+	&[disabled]:hover,
+	&[disabled]:focus {
+		background-color: $background;
+		border: 1px solid $borderColor;
+		color: $color;
+		outline: none;
+		text-decoration: none;
+	}
+
+	&:after {
+		content: " ";
+		width: 0;
+	}
+
+	&::-moz-focus-inner {
+		border: 0;
+		padding: 0;
+	}
+
+	&.vui-disabled,
+	&[disabled] {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	&:hover,
+	&:focus {
+		border-color: $hoverBorderColor;
+		background-color: $hoverBackground;
+	}
+
+}
+
+.vui-button {
+	@include _vui-button(
+			$color: $d2l-color-ferrite,
+			$background: $d2l-color-woolonardo,
+			$borderColor: $d2l-color-titanius,
+			$hoverBackground: $d2l-color-gypsum,
+			$hoverBorderColor: $d2l-color-titanius
+		);
+}
+
+.vui-button-primary {
+	@include _vui-button(
+			$color: $d2l-color-white,
+			$background: $d2l-color-celestine,
+			$borderColor: $d2l-color-celestuba,
+			$hoverBackground: $d2l-color-celestuba,
+			$hoverBorderColor: $d2l-color-celestuba
+		);
+}

--- a/src/deprecated/icons.scss
+++ b/src/deprecated/icons.scss
@@ -1,4 +1,4 @@
-@import '../bower_components/d2l-icons/icons.scss';
+@import '../../bower_components/d2l-icons/icons.scss';
 
 [class*=" d2l-icon-"],
 [class^="d2l-icon-"],

--- a/src/deprecated/link.scss
+++ b/src/deprecated/link.scss
@@ -1,4 +1,6 @@
-@import '../bower_components/d2l-colors/d2l-colors.scss';
+@import '../../bower_components/d2l-colors/d2l-colors.scss';
+
+/* these are still referenced by a few FRAs */
 
 @mixin _vui-link-focus() {
 	color: $d2l-color-celestuba;

--- a/src/deprecated/offscreen.scss
+++ b/src/deprecated/offscreen.scss
@@ -1,0 +1,5 @@
+@import '../../bower_components/d2l-offscreen/offscreen.scss';
+
+.vui-offscreen {
+	@include d2l-offscreen();
+}

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -1,5 +1,4 @@
 @import '../bower_components/d2l-colors/d2l-colors.scss';
-@import 'node_modules/vui-typography/px-to-base-rem.scss';
 @import '../bower_components/vui-loading-spinner/loadingSpinner.scss';
 
 $dialog-media-break-small: "(max-device-width: 767px), screen and (max-width:767px)";

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 @import 'node_modules/vui-typography/px-to-base-rem.scss';
 @import '../bower_components/vui-loading-spinner/loadingSpinner.scss';
 
@@ -129,7 +129,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 .ddial_o2,
 .d2l-dialog-inner {
 	background-color: $dialog-background-color;
-	border: 1px solid $vui-color-titanius;
+	border: 1px solid $d2l-color-titanius;
 	border-radius: 0.4rem;
 	box-shadow: 0 2px 12px rgba(86,90,92,0.25);
 	box-sizing: border-box;
@@ -296,7 +296,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	}
 
 	&:hover {
-		border-color: $vui-color-pressicus;
+		border-color: $d2l-color-pressicus;
 	}
 
 	&:hover > span {

--- a/src/file-link.scss
+++ b/src/file-link.scss
@@ -1,15 +1,15 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-filelink-link {
 	& > .d2l-filelink-link-text {
-		color: $vui-color-celestine;
+		color: $d2l-color-celestine;
 		cursor: pointer;
 		font-weight: normal;
 		text-decoration: none;
 	}
 	&:hover > .d2l-filelink-link-text,
 	&:focus > .d2l-filelink-link-text {
-		color: $vui-color-celestuba;
+		color: $d2l-color-celestuba;
 		text-decoration: underline;
 	}
 }

--- a/src/floating-container.scss
+++ b/src/floating-container.scss
@@ -1,10 +1,10 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 @import 'node_modules/vui-typography/headings.scss';
 @import 'node_modules/vui-typography/px-to-base-rem.scss';
 
 .d2l-floating-container {
-	border: solid 1px $vui-color-titanius;
-	background-color: $vui-color-white;
+	border: solid 1px $d2l-color-titanius;
+	background-color: $d2l-color-white;
 	border-radius: px-to-base-rem(8px);
 	box-shadow: 0 2px 12px 0 rgba(86, 90, 92, .2);
 }

--- a/src/floating-container.scss
+++ b/src/floating-container.scss
@@ -1,32 +1,34 @@
 @import '../bower_components/d2l-colors/d2l-colors.scss';
-@import 'node_modules/vui-typography/headings.scss';
-@import 'node_modules/vui-typography/px-to-base-rem.scss';
 
 .d2l-floating-container {
 	border: solid 1px $d2l-color-titanius;
 	background-color: $d2l-color-white;
-	border-radius: px-to-base-rem(8px);
+	border-radius: 0.4rem;
 	box-shadow: 0 2px 12px 0 rgba(86, 90, 92, .2);
 }
 
 .d2l-floating-container-close {
-	margin: px-to-base-rem(5px);
-	margin-left: px-to-base-rem(-24px);
+	margin: 0.25rem;
+	margin-left: -1.2rem;
 }
 
 .d2l-floating-container-titlebar .d2l-heading {
-	@include vui-typography-heading2(
-		$margin: 0 px-to-base-rem(24px) 0 0
-	);
-	padding: px-to-base-rem(6px);
+	color: $d2l-color-ferrite;
+	font-family: inherit;
+	font-size: 1.5rem;
+	font-weight: 300;
+	line-height: 2.25rem;
+	letter-spacing: -0.015rem;
+	margin: 0 1.2rem 0 0;
+	padding: 0.3rem;
 }
 
 [dir='rtl'] .d2l-floating-container-close {
-	margin-left: px-to-base-rem(5px);
-	margin-right: px-to-base-rem(-24px);
+	margin-left: 0.25rem;
+	margin-right: -1.2rem;
 }
 
 [dir='rtl'] .d2l-floating-container-titlebar .d2l-heading {
 	margin-right: 0;
-	margin-left: px-to-base-rem(24px);
+	margin-left: 1.2rem;
 }

--- a/src/grid.scss
+++ b/src/grid.scss
@@ -1,5 +1,5 @@
 @import 'node_modules/vui-table/table.scss';
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 @import 'node_modules/vui-typography/small-text.scss';
 
 /* MVC Grid */
@@ -47,7 +47,7 @@
 	& > tbody.yui-dt-message > tr:last-child {
 		& th,
 		  td {
-			border-bottom: 1px solid $vui-color-titanius;
+			border-bottom: 1px solid $d2l-color-titanius;
 		}
 
 		& > :first-child {
@@ -96,7 +96,7 @@
 
 	& .d_lastRow > td,
 	  .d_lastRow > th {
-		border-bottom: 1px solid $vui-color-titanius;
+		border-bottom: 1px solid $d2l-color-titanius;
 	}
 
 	& >:only-child {
@@ -115,7 +115,7 @@
 		& > tr.d_gactr + tr.d_gh > th,
 		  > tr.fgskip + tr.d_gh > th,
 		  > tbody + tr.d_gh > th {
-			border-top: 1px solid $vui-color-titanius;
+			border-top: 1px solid $d2l-color-titanius;
 		}
 
 		& > .d_gh > th {
@@ -129,7 +129,7 @@
 
 		& > tr.d_gs.d_lastRow > th,
 		  > tr.d_gs.d_lastRow > td {
-			border-bottom-color: $vui-color-celestine-light-2;
+			border-bottom-color: $d2l-color-celestine-light-2;
 		}
 
 		& > tr:not(.d_gactr):not(.d_gh) {
@@ -143,10 +143,10 @@
 			}
 		}
 		& > tr:not(.d_gactr) > :first-child {
-			border-left: 1px solid $vui-color-titanius;
+			border-left: 1px solid $d2l-color-titanius;
 		}
 		[dir='rtl'] & > tr:not(.d_gactr) > :last-child {
-			border-left: 1px solid $vui-color-titanius;
+			border-left: 1px solid $d2l-color-titanius;
 		}
 
 		[dir='rtl'] & > tr:not(.d_gactr) > :first-child {
@@ -170,7 +170,7 @@
 		& > tr.d_ggl2 {
 			& td,
 			  th {
-				background-color:$vui-color-regolith;
+				background-color:$d2l-color-regolith;
 			}
 		}
 		& > tr.d_ggl2 > :first-child {

--- a/src/grid.scss
+++ b/src/grid.scss
@@ -1,6 +1,5 @@
 @import 'node_modules/vui-table/table.scss';
 @import '../bower_components/d2l-colors/d2l-colors.scss';
-@import 'node_modules/vui-typography/small-text.scss';
 
 /* MVC Grid */
 .d2l-grid-cell-sel {
@@ -16,14 +15,19 @@
 }
 
 .d2l-grid-header-cell a,
-.d2l-grid-header-cell a:visited {
-	@include vui-typography-small-text();
+.d2l-grid-header-cell a:visited,
+.d2l-grid-header-cell a:hover {
+	color: $d2l-color-ferrite;
+	font-family: inherit;
+	font-size: 0.7rem;
+	font-weight: 400;
+	line-height: 1rem;
+	letter-spacing: 0.02rem;
+	margin: 1rem 0 1rem 0;
 	margin: 0;
 }
 .d2l-grid-header-cell a:hover {
-	@include vui-typography-small-text();
 	text-decoration: underline;
-	margin: 0;
 }
 
 /* Legacy data grid is .yui-dt */

--- a/src/link.scss
+++ b/src/link.scss
@@ -1,0 +1,31 @@
+@import '../bower_components/d2l-colors/d2l-colors.scss';
+
+@mixin _vui-link-focus() {
+	color: $d2l-color-celestuba;
+	text-decoration: underline;
+	outline-width: 0;
+}
+
+@mixin _vui-link($font-weight: normal) {
+	&,
+	&:visited,
+	&:link,
+	&:active {
+		color: $d2l-color-celestine;
+		font-weight: $font-weight;
+		text-decoration: none;
+		cursor: pointer;
+	}
+	&:hover,
+	&:focus {
+		@include _vui-link-focus;
+	}
+}
+
+.vui-link {
+	@include _vui-link;
+}
+
+.vui-link-main {
+	@include _vui-link($font-weight: 700);
+}

--- a/src/offscreen.scss
+++ b/src/offscreen.scss
@@ -1,5 +1,0 @@
-@import '../bower_components/d2l-offscreen/offscreen.scss';
-
-.vui-offscreen {
-	@include d2l-offscreen();
-}

--- a/src/page-two-column.scss
+++ b/src/page-two-column.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-column-side {
 	background: #FFF;
@@ -96,7 +96,7 @@
 .d2l-column-flip-main,
 .d2l-column-main,
 .d2l-page-header-dark {
-	background-color: $vui-color-regolith;
+	background-color: $d2l-color-regolith;
 }
 
 .d2l-page-header-dark {

--- a/src/page-two-panel-selector.scss
+++ b/src/page-two-panel-selector.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-twopanelselector-header {
 	padding: 11px 10px 0 10px;
@@ -15,12 +15,12 @@
 
 .d2l-twopanelselector-side.d2l-twopanelselector-side-sep,
 .d2l-twopanelselector-side-bg.d2l-twopanelselector-side-sep {
-	border-right: 1px solid $vui-color-gypsum;
-	background: linear-gradient(to right, rgba(249,250,251,0) 0%, $vui-color-regolith 400px);
+	border-right: 1px solid $d2l-color-gypsum;
+	background: linear-gradient(to right, rgba(249,250,251,0) 0%, $d2l-color-regolith 400px);
 
 	[dir='rtl'] & {
-		background: linear-gradient(to left, rgba(249,250,251,0) 0%, $vui-color-regolith 400px);
-		border-left: 1px solid $vui-color-gypsum;
+		background: linear-gradient(to left, rgba(249,250,251,0) 0%, $d2l-color-regolith 400px);
+		border-left: 1px solid $d2l-color-gypsum;
 		border-right: none;
 	}
 }

--- a/src/page.scss
+++ b/src/page.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 #d2l_body,
 .d2l-body {
@@ -37,7 +37,7 @@
 .d2l-page-main,
 .d2l-page-bg > div,
 .d2l-page-bg-full > div /* legacy full screen */ {
-	background-color: $vui-color-white;
+	background-color: $d2l-color-white;
 }
 
 .d2l-max-width {

--- a/src/text-image-link.scss
+++ b/src/text-image-link.scss
@@ -1,15 +1,15 @@
-@import 'node_modules/vui-colors/colors.scss';
+@import '../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-text-imagelink {
 	& > .d2l-text-imagelink-text {
-		color: $vui-color-celestine;
+		color: $d2l-color-celestine;
 		cursor: pointer;
 		font-weight: normal;
 		text-decoration: none;
 	}
 	&:hover > .d2l-text-imagelink-text,
 	&:focus > .d2l-text-imagelink-text {
-		color: $vui-color-celestuba;
+		color: $d2l-color-celestuba;
 		text-decoration: underline;
 	}
 }

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -1,7 +1,7 @@
 @import '../bower_components/vui-focus/focus.css.scss';
 @import './deprecated/icons.scss';
 @import '../bower_components/jquery-vui-accordion/accordion.css.scss';
-@import '../node_modules/vui-breadcrumbs/breadcrumbs.css.scss';
+@import '../bower_components/vui-breadcrumbs/breadcrumbs.css.scss';
 @import './deprecated/button.scss';
 @import '../node_modules/vui-dropdown/dropdown.css.scss';
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -7,7 +7,7 @@
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';
 @import '../bower_components/jquery-vui-collapsible-section/collapsibleSection.css.scss';
 @import '../bower_components/vui-field/field.css.scss';
-@import '../node_modules/vui-link/link.css.scss';
+@import 'link.scss';
 @import '../node_modules/vui-list/list.css.scss';
 @import '../node_modules/jquery-vui-more-less/moreLess.css.scss';
 @import '../node_modules/vui-image-action/image-action.css.scss';

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -2,7 +2,7 @@
 @import './deprecated/icons.scss';
 @import '../bower_components/jquery-vui-accordion/accordion.css.scss';
 @import '../node_modules/vui-breadcrumbs/breadcrumbs.css.scss';
-@import '../node_modules/vui-button/button.css.scss';
+@import './deprecated/button.scss';
 @import '../node_modules/vui-dropdown/dropdown.css.scss';
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';
 @import '../bower_components/jquery-vui-collapsible-section/collapsibleSection.css.scss';

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -1,5 +1,5 @@
 @import '../bower_components/vui-focus/focus.css.scss';
-@import 'icons.scss';
+@import './deprecated/icons.scss';
 @import '../bower_components/jquery-vui-accordion/accordion.css.scss';
 @import '../node_modules/vui-breadcrumbs/breadcrumbs.css.scss';
 @import '../node_modules/vui-button/button.css.scss';
@@ -7,12 +7,12 @@
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';
 @import '../bower_components/jquery-vui-collapsible-section/collapsibleSection.css.scss';
 @import '../bower_components/vui-field/field.css.scss';
-@import 'link.scss';
+@import './deprecated/link.scss';
 @import '../node_modules/vui-list/list.css.scss';
 @import '../node_modules/jquery-vui-more-less/moreLess.css.scss';
 @import '../node_modules/vui-image-action/image-action.css.scss';
 @import '../node_modules/vui-input/input.css.scss';
-@import 'offscreen.scss';
+@import './deprecated/offscreen.scss';
 @import '../node_modules/vui-table/table.css.scss';
 @import '../node_modules/vui-validation/validation.css.scss';
 @import '../bower_components/vui-loading-spinner/loadingSpinner.css.scss';

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -6,7 +6,7 @@
 @import '../node_modules/vui-dropdown/dropdown.css.scss';
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';
 @import '../bower_components/jquery-vui-collapsible-section/collapsibleSection.css.scss';
-@import '../node_modules/vui-field/field.css.scss';
+@import '../bower_components/vui-field/field.css.scss';
 @import '../node_modules/vui-link/link.css.scss';
 @import '../node_modules/vui-list/list.css.scss';
 @import '../node_modules/jquery-vui-more-less/moreLess.css.scss';


### PR DESCRIPTION
@dbatiste, @njostonehouse, @capajon, @ryantmer 

First set of a series of changes to BSI that will upgrade it to use the `d2l-*` version of our UI components instead of `vui-*`. Accompanying this will be a change to the ILP-Core to pick up some of the new web component custom elements (e.g. `<button is="d2l-button">` instead of `<button is="vui-button">`) and class names.

This is also the beginning of removing our dependency on those `#bsi-wc` branches some of the components needed in order to still reference the old Sass mixins until they were upgraded to web components themselves.