### PR TITLE
Fix legacy layout of right aligned buttons.

### DIFF
--- a/button.html
+++ b/button.html
@@ -11,6 +11,15 @@
 				margin-right: 0;
 			}
 
+			.dlay_r > .d2l-button {
+				margin-left: var(--d2l-button-spacing);
+				margin-right: 0;
+			}
+			[dir='rtl'] .dlay_r > .d2l-button {
+				margin-right: var(--d2l-button-spacing);
+				margin-left: 0;
+			}
+
 		</style>
 	</template>
 </dom-module>


### PR DESCRIPTION
This change effectively flips the LTR right margin on buttons when inside of legacy right-aligned layout.  Corresponding is the RTL equivalent.  Without this change there is a 0.75rem right margin that bumps the button in, causing the right-most button to not be aligned with the containing edge.