### PR TITLE
upgrading to vui-loading-spinner 2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "vui-focus": "~0.7.1",
     "vui-input": "~1.6.0",
     "vui-list": "~1.1.0",
-    "vui-loading-spinner": "~1.0.0",
     "vui-table": "~0.1.0",
     "vui-validation": "~1.1.0"
   },

--- a/bsi.html
+++ b/bsi.html
@@ -5,3 +5,4 @@
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-navigation/navigation.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../vui-loading-spinner/loading-spinner.html">

--- a/src/deprecated/loadingSpinner.css.scss
+++ b/src/deprecated/loadingSpinner.css.scss
@@ -1,0 +1,6 @@
+@import './loadingSpinner';
+
+.vui-loading-spinner {
+	@include vui-loading-spinner;
+}
+

--- a/src/deprecated/loadingSpinner.scss
+++ b/src/deprecated/loadingSpinner.scss
@@ -1,0 +1,41 @@
+$vui-loading-spinner-size: 70px !default;
+$vui-loading-spinner-thickness: 5px !default;
+$vui-loading-spinner-color: #cccccc !default;
+
+@mixin vui-loading-spinner(
+		$size: $vui-loading-spinner-size,
+		$thickness: $vui-loading-spinner-thickness,
+		$color: $vui-loading-spinner-color
+	) {
+
+	$halfSize: $size / 2;
+	$halfThickness: $thickness / 2;
+
+	border: $thickness solid $color;
+	border-radius: 50%;
+	box-sizing: border-box;
+	display: inline-block;
+	overflow: hidden;
+	position: relative;
+	width: $size;
+	height: $size;
+
+    div {
+		animation: vui-loading-spinner-animation 1.3s cubic-bezier(0.165, 0.840, 0.440, 1.000) infinite;
+		transform-origin: $halfThickness $halfThickness;
+		background: $color;
+		border-radius: $halfThickness;
+		content: '';
+		display: block;
+		position: absolute;
+		width: $thickness;
+		height: $halfSize;
+		left: $halfSize - 1.5 * $thickness;
+		top: $halfSize - 1.5 * $thickness;
+    }
+
+    @keyframes vui-loading-spinner-animation {
+        from { transform: rotate(-180deg); }
+        to { transform: rotate(180deg); }
+    }
+}

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -1,5 +1,5 @@
 @import '../bower_components/d2l-colors/d2l-colors.scss';
-@import '../bower_components/vui-loading-spinner/loadingSpinner.scss';
+@import './deprecated/loadingSpinner.scss';
 
 $dialog-media-break-small: "(max-device-width: 767px), screen and (max-width:767px)";
 $dialog-media-break-small-iframe: "(max-device-width: 767px)";

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -14,4 +14,4 @@
 @import './deprecated/offscreen.scss';
 @import '../bower_components/vui-table/table.css.scss';
 @import '../bower_components/vui-validation/validation.css.scss';
-@import '../bower_components/vui-loading-spinner/loadingSpinner.css.scss';
+@import './deprecated/loadingSpinner.css.scss';


### PR DESCRIPTION
@dlockhart @mdedys 

The ASV needs the new vui-loading-spinner in this rally story: https://rally1.rallydev.com/#/42651186647d/detail/userstory/50630921204

@mdedys is it ready? @dlockhart is a name change necessary?