### PR TITLE
Update d2l-my-courses to v0.8.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "d2l-image-action": "~0.4.3",
     "d2l-link": "~3.0.0",
     "d2l-loading-spinner": "~3.0.0",
-    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.8.0",
+    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.8.1",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.7.0",
     "d2l-offscreen": "~2.1.0",
     "d2l-typography": "~4.0.1",


### PR DESCRIPTION
This version isn't available quite yet, but Travis is being incredibly slow, so CI is many minutes to start anyway... by the time it does, this version should be up.