### PR TITLE
line height fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: "5"
 sudo: false
 after_success:
 - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm run

--- a/headings.html
+++ b/headings.html
@@ -44,7 +44,7 @@
 			}
 
 			.d2l-typography .bsi-set-solid {
-				line-height: 100%;
+				line-height: normal;
 				margin: 0;
 				padding: 0;
 			}

--- a/package.json
+++ b/package.json
@@ -37,27 +37,27 @@
   },
   "homepage": "https://github.com/Brightspace/brightspace-integration",
   "dependencies": {
-    "bower": "^1.5.2"
+    "bower": "^1.7.9"
   },
   "devDependencies": {
-    "autoprefixer": "^5.2.0",
-    "browserify": "^11.2.0",
-    "clean-css": "^3.4.9",
-    "cpy": "^3.4.0",
+    "autoprefixer": "^6.4.0",
+    "browserify": "^13.1.0",
+    "clean-css": "^3.4.19",
+    "cpy-cli": "^1.0.1",
     "d2l-intl": "^0.3.2",
-    "eslint": "^1.6.0",
-    "eslint-config-brightspace": "0.0.2",
-    "eslint-plugin-react": "^3.5.1",
-    "frau-publisher": "^2.5.2",
-    "http-server": "^0.8.0",
-    "lie": "^3.0.1",
-    "node-sass": "^3.3.2",
-    "postcss-cli": "^2.1.0",
-    "posthtml-cli": "^0.2.4",
+    "eslint": "^3.4.0",
+    "eslint-config-brightspace": "0.2.1",
+    "eslint-plugin-react": "^6.2.0",
+    "frau-publisher": "^2.5.3",
+    "http-server": "^0.9.0",
+    "lie": "^3.1.0",
+    "node-sass": "^3.8.0",
+    "postcss-cli": "^2.6.0",
+    "posthtml-cli": "^0.2.5",
     "posthtml-minifier": "^0.1.0",
-    "rimraf": "^2.4.2",
-    "uglify-js": "^2.6.1",
-    "uglifyify": "^3.0.1",
-    "web-component-shards": "^1.1.3"
+    "rimraf": "^2.5.4",
+    "uglify-js": "^2.7.3",
+    "uglifyify": "^3.0.2",
+    "web-component-shards": "^1.1.4"
   }
 }


### PR DESCRIPTION
FYI @njostonehouse, @dbatiste, @capajon 

Using `normal` line-height instead of `100%` to avoid clipping of extenders (e.g. "y" and "g") in certain browsers. In general I think we should always be using `normal` when the desired effect is for the text to be "as short as possible". I'm going to adjust a few places in the LMS as well that are doing this.

Reference: http://stackoverflow.com/questions/25470084/minimum-line-height-to-ensure-text-is-not-cut-off