### PR TITLE
Two panel responsive collapsing columns pass one

### DIFF
--- a/src/page-two-panel-selector.scss
+++ b/src/page-two-panel-selector.scss
@@ -58,3 +58,19 @@
 .d2l-twopanelselector-padding {
 	padding-top: 30px;
 }
+
+@media(max-width: 1000px) {
+	.d2l-twopanelselector-wrapper.d2l-repsonsive-collapse-layout {
+		.d2l-box-layout {
+			display: block;
+		}
+		.d2l-twopanelselector-side {
+			display: block;
+			max-width: none;
+			width: auto;
+		}
+		.d2l-twopanelselector-main {
+			display: block;
+		}
+	}
+}

--- a/src/page-two-panel-selector.scss
+++ b/src/page-two-panel-selector.scss
@@ -61,16 +61,16 @@
 
 @media(max-width: 1000px) {
 	.d2l-twopanelselector-wrapper.d2l-repsonsive-collapse-layout {
-		.d2l-box-layout {
+		> .d2l-box-layout {
 			display: block;
-		}
-		.d2l-twopanelselector-side {
-			display: block;
-			max-width: none;
-			width: auto;
-		}
-		.d2l-twopanelselector-main {
-			display: block;
+			> .d2l-twopanelselector-side {
+				display: block;
+				max-width: none;
+				width: auto;
+			}
+			> .d2l-twopanelselector-main {
+				display: block;
+			}
 		}
 	}
 }


### PR DESCRIPTION
@dlockhart This is related to the "useResponsiveCollapseLayout" changes in the LE that we were holding off putting in 10.6.6.