### PR TITLE
Adjust two panel mobile styling further

### DIFF
--- a/src/page-two-panel-selector.scss
+++ b/src/page-two-panel-selector.scss
@@ -68,6 +68,10 @@
 		}
 		.d2l-twopanelselector-main {
 			display: block;
+			min-height: 100vh;
 		}
+	}
+	.d2l-twopanelselector-side-bg.d2l-repsonsive-collapse-layout {
+		display: none;
 	}
 }


### PR DESCRIPTION
@omsmith @njostonehouse 

There will be a corresponding change in the LE to add .d2l-repsonsive-collapse-layout to .d2l-twopanelselector-side-bg (but this can still go in without it).

Although with a 100vh on the main panel the bg wouldn't actually show anymore, but this feels more comprehensive.