### PR TITLE
Fix legacy dialogs on mobile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "jquery-vui-more-less": "^1.2.0",
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.5.0",
+    "sass-flex-mixin": "^1.0.3",
     "vui-breadcrumbs": "^2.1.0",
     "vui-dropdown": "~0.7.1",
     "vui-field": "^1.2.0",

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -72,19 +72,6 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	width: 400px;
 }
 
-.ddial_o,
-.d2l-dialog {
-	@media #{$dialog-media-break-small} {
-		width: 100% !important;
-		height: 100% !important;
-		left: auto !important;
-		padding: 0 !important;
-		top: 0 !important;
-		position: fixed !important;
-	}
-}
-
-
 .d2l-dialog-document-body {
 	background-color: transparent;
 	height: 100%;
@@ -94,12 +81,6 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	flex-grow: 2;
 	overflow: auto;
 	position: relative;
-}
-
-.ddial_o .ddial_f {
-	@media #{$dialog-media-break-small} {
-		display: none !important;
-	}
 }
 
 .d2l-dialog-flex {
@@ -132,13 +113,6 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	box-shadow: 0 2px 12px rgba(86,90,92,0.25);
 	box-sizing: border-box;
 	height: 100% !important;
-
-	@media #{$dialog-media-break-small} {
-		border-radius: 0 !important;
-		width: 100% !important;
-		height: 100% !important;
-		position: fixed;
-	}
 
 	> .d2l-dialog-frame {
 		width: 100% !important;
@@ -181,12 +155,6 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 .d2l-dialog-footer-container {
 	bottom:0;
 	width:100%;
-}
-
-.d2l-dialog-footer .d2l-dialog-resize {
-	@media #{$dialog-media-break-small-iframe} {
-		display: none !important;
-	}
 }
 
 .d2l-dialog-resize {
@@ -303,4 +271,54 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 		background-image: $dialog-close-hover;
 	}
 
+}
+
+@media #{$dialog-media-break-small} {
+
+	.ddial_o,
+	.d2l-dialog {
+		width: 100% !important;
+		height: 100% !important;
+		left: auto !important;
+		padding: 0 !important;
+		top: 0 !important;
+		position: fixed !important;
+	}
+
+	.ddial_o2,
+	.d2l-dialog-inner {
+		border-radius: 0 !important;
+		width: 100% !important;
+		height: 100% !important;
+		position: fixed;
+	}
+
+	.ddial_o .ddial_f {
+		display: none !important;
+	}
+
+	.d2l-dialog-footer .d2l-dialog-resize {
+		display: none !important;
+	}
+
+	.ddial_o2 {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.ddial_i {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+	}
+
+	.ddial_c {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.ddial_c_frame {
+		flex-grow: 1;
+	}
 }

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -78,15 +78,15 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 }
 
 .d2l-dialog-body {
-	flex-grow: 2;
+	@include flex-grow(2);
 	overflow: auto;
 	position: relative;
 }
 
 .d2l-dialog-flex {
 	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
+	@include flexbox;
+	@include flex-direction(column);
 	height: 100%;
 	width: 100% !important;
 	position: absolute;
@@ -95,7 +95,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 
 .d2l-dialog-flex > .d2l-dialog-footer,
 .d2l-dialog-flex > .d2l-dialog-footer-container {
-	align-self: flex-end;
+	@include align-self(flex-end);
 	width: 100%;
 }
 
@@ -120,7 +120,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 }
 
 .d2l-dialog-title {
-	align-self: flex-start;
+	@include align-self(flex-start);
 	position: relative;
 	width: 100%;
 	margin: -0.25rem 0.25rem 0.25rem 0;
@@ -302,23 +302,23 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	}
 
 	.ddial_o2 {
-		display: flex;
-		flex-direction: column;
+		@include flexbox;
+		@include flex-direction(column);
 	}
 
 	.ddial_i {
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
+		@include flexbox;
+		@include flex-direction(column);
+		@include flex-grow(1);
 	}
 
 	.ddial_c {
-		flex-grow: 1;
-		display: flex;
-		flex-direction: column;
+		@include flexbox;
+		@include flex-grow(1);
+		@include flex-direction(column);
 	}
 
 	.ddial_c_frame {
-		flex-grow: 1;
+		@include flex-grow(1);
 	}
 }

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -14,3 +14,4 @@
 @import './deprecated/offscreen.scss';
 @import './deprecated/table.css.scss';
 @import '../bower_components/vui-validation/validation.css.scss';
+@import '../bower_components/sass-flex-mixin/_flex.scss';


### PR DESCRIPTION
@njostonehouse @dlockhart 

The issue this is solving is legacy dialogs opening with a height of 1px on the content.  This happened because of some new responsive rules that set heights to 100%.  The JS tries to dynamically set the height based on a few (confusing) things - and that CSS messes it up.

The fix ended up being fairly simple, just using flexbox basically.  I'll note that I tried a lot of other things first in the LE, mostly with how the javascript worked, but it is really confusing and never quite worked well in all situations.  Flexbox seems to take care of things so I'm happy enough with it.  I don't think dialogs are any better/worse overall with this change (but mostly work now so that's good).