### PR TITLE
DE23046: Bump typography version for small and standard font classes.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.13.6",
     "d2l-offscreen": "^2.1.0",
     "d2l-table": "^0.2.8",
-    "d2l-typography": "^4.2.2",
+    "d2l-typography": "^4.3.2",
     "jquery-vui-accordion": "~0.3.0",
     "jquery-vui-collapsible-section": "^1.2.0",
     "jquery-vui-change-tracking": "~0.4.0",


### PR DESCRIPTION
Patch version 2 was a typo when I released Typography 4.3, but I don't think it will create any problems to be missing versions .0 and .1.