### PR TITLE
Dbatiste/instrument

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.15.4",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.14.0",
     "d2l-offscreen": "^2.1.0",
+    "d2l-performance": "^0.0.1",
     "d2l-table": "^0.2.9",
     "d2l-typography": "^5.0.1",
     "jquery-vui-accordion": "~0.3.0",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "d2l-link": "^3.0.1",
     "d2l-loading-spinner": "^4.0.0",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.15.4",
-    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.14.0",
+    "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.14.1",
     "d2l-offscreen": "^2.1.0",
     "d2l-performance": "^0.0.1",
     "d2l-table": "^0.2.9",

--- a/bsi.html
+++ b/bsi.html
@@ -1,4 +1,5 @@
 <link rel="import" href="bsi-style.html">
+<link rel="import" href="../d2l-performance/d2l-performance.html">
 <link rel="import" href="../d2l-button/d2l-button.html">
 <link rel="import" href="../d2l-button/d2l-floating-buttons.html">
 <link rel="import" href="../d2l-image-action/d2l-image-action.html">

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -10,8 +10,10 @@
 		}
 
 		var timing = performance.timing;
+
+		D2L.Performance.measure('domInteractive', 'navigationStart', 'domInteractive');
+
 		var measures = {
-			'domInteractive': timing.domInteractive - timing.navigationStart,
 			'domContentLoaded': timing.domContentLoadedEventEnd - timing.navigationStart,
 			'load': timing.loadEventStart - timing.navigationStart
 		};

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -23,7 +23,7 @@
 			measures[custom[i].name] = Math.floor(custom[i].duration);
 		}
 
-		console.log('measures', measures);
+		D2L.Performance.timing = measures;
 
 	}
 

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -1,34 +1,73 @@
 (function() {
 	'use strict';
 
-	var pageReady, navReady = false;
+	var pageReady, pageLoaded, navReady = false;
+
+	function logMeasures() {
+
+		if (!pageReady || !navReady || !pageLoaded) {
+			return;
+		}
+
+		var timing = performance.timing;
+		var measures = {
+			'domInteractive': timing.domInteractive - timing.navigationStart,
+			'domContentLoaded': timing.domContentLoadedEventEnd - timing.navigationStart,
+			'load': timing.loadEventStart - timing.navigationStart
+		};
+
+		var custom = D2L.Performance.getEntriesByType('measure');
+		for(var i=0; i<custom.length; i++) {
+			measures[custom[i].name] = Math.floor(custom[i].duration);
+		}
+
+		console.log('measures', measures);
+
+	}
 
 	function check() {
 		if (pageReady && navReady) {
+			D2L.Performance.measure('d2l.page.display');
 			document.body.classList.remove('d2l-page-loading');
+			logMeasures();
 		}
 	}
 
 	function pageIsReady() {
+
 		if (pageReady) {
 			return;
 		}
+
 		document.body.addEventListener('d2l-navigation-ready', navIsReady);
 		var navs = document.getElementsByTagName('d2l-navigation');
 		if (navs.length === 0 || !navs[0].hasAttribute('loading')) {
 			navIsReady();
 		}
+
 		pageReady = true;
 		check();
+
 	}
 
 	function navIsReady() {
+		if (navReady) {
+			return;
+		}
 		navReady = true;
 		check();
 	}
 
+	addEventListener('load', function(e) {
+		pageLoaded = true;
+		logMeasures();
+	});
+
 	if (window.WebComponents) {
-		addEventListener('WebComponentsReady', pageIsReady);
+		addEventListener('WebComponentsReady', function() {
+			D2L.Performance.measure('WebComponentsReady');
+			pageIsReady();
+		});
 	} else {
 		if (document.readyState === 'interactive' || document.readyState === 'complete') {
 			pageIsReady();


### PR DESCRIPTION
@dlockhart : these changes add a couple of measurements, and logs the results to console (temp).  We can adjust as needed.  I expect the logging to console part to be temporary until we have a place to store metrics.

* update to latest d2l-navigation (to get `d2l.navigation` measurement)
* add `d2l.page.display` measurement (first meaningful paint)
* add `WebComponentsReady` measurement
* add `domInteractive` measurement
* log `domContentLoaded` duration
* log `load` duration

We can differentiate between before & after handlders for `domContentLoaded` and `load`.  Currently I have them aligned with the chrome timeline (blue and red lines respectively).

I don't really like all the measurements that go from 0 -> x on the timeline.  I wish simple markers could be shown on the timeline.  Anyway, maybe we tweak when we know better what's useful.