### PR TITLE
no longer waiting for the "nav ready" event to fade the page in

### DIFF
--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -28,11 +28,12 @@
 	}
 
 	function check() {
-		if (pageReady && navReady) {
-			D2L.Performance.measure('d2l.page.display');
-			document.body.classList.remove('d2l-page-loading');
-			logMeasures();
+		if (!pageReady) {
+			return;
 		}
+		D2L.Performance.measure('d2l.page.display');
+		document.body.classList.remove('d2l-page-loading');
+		logMeasures();
 	}
 
 	function pageIsReady() {
@@ -57,7 +58,7 @@
 			return;
 		}
 		navReady = true;
-		check();
+		logMeasures();
 	}
 
 	addEventListener('load', function(e) {
@@ -78,9 +79,6 @@
 		}
 	}
 
-	setTimeout(function() {
-		pageIsReady();
-		navIsReady();
-	}, 10000);
+	setTimeout(pageIsReady, 10000);
 
 })();


### PR DESCRIPTION
@dbatiste look OK? Basically only waiting for the WC ready event before fading in the page. I still want to do a lot of work to navigation so that it progressively loads while still showing _something_, but that's separate.