### PR TITLE
firing an event when perf measures are ready so we can do things with them

### DIFF
--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -19,8 +19,15 @@
 		};
 
 		var custom = D2L.Performance.getEntriesByType('measure');
-		for(var i=0; i<custom.length; i++) {
+		for (var i = 0; i < custom.length; i++) {
 			measures[custom[i].name] = Math.floor(custom[i].duration);
+		}
+
+		for (var m in measures) {
+			document.dispatchEvent(new CustomEvent('D2LPerformanceMeasure', {
+				bubbles: true,
+				detail: { name: m, value: measures[m] }
+			}));
 		}
 
 		D2L.Performance.timing = measures;


### PR DESCRIPTION
@dbatiste @omsmith The main use case for this right now is so that we can grab this data when it's ready and send it off to AppDynamics.