### PR TITLE
Page loading tweaks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,8 @@
   },
   "rules": {
       "strict": 2
+  },
+  "globals": {
+    "D2L": true
   }
 }

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -1,11 +1,11 @@
 (function() {
 	'use strict';
 
-	var pageReady, pageLoaded, navReady = false;
+	var pageReady, pageLoaded = false;
 
 	function logMeasures() {
 
-		if (!pageReady || !navReady || !pageLoaded) {
+		if (!pageReady || !pageLoaded) {
 			return;
 		}
 
@@ -31,26 +31,12 @@
 			return;
 		}
 
-		document.body.addEventListener('d2l-navigation-ready', navIsReady);
-		var navs = document.getElementsByTagName('d2l-navigation');
-		if (navs.length === 0 || !navs[0].hasAttribute('loading')) {
-			navIsReady();
-		}
-
 		pageReady = true;
 		check();
 
 	}
 
-	function navIsReady() {
-		if (navReady) {
-			return;
-		}
-		navReady = true;
-		logMeasures();
-	}
-
-	addEventListener('load', function(e) {
+	addEventListener('load', function() {
 		pageLoaded = true;
 		logMeasures();
 	});

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -1,51 +1,27 @@
 (function() {
 	'use strict';
 
-	var pageReady, pageLoaded = false;
+	var pageReady = false;
 
-	function logMeasures() {
-
-		if (!pageReady || !pageLoaded) {
+	function pageIsReady() {
+		if (pageReady) {
 			return;
 		}
+		pageReady = true;
+		D2L.Performance.measure('d2l.page.display', 'fetchStart');
+		document.body.classList.remove('d2l-page-loading');
+	}
 
+	addEventListener('load', function() {
 		D2L.Performance.measure('d2l.page.preFetch', 'navigationStart', 'fetchStart');
 		D2L.Performance.measure('d2l.page.domInteractive', 'fetchStart', 'domInteractive');
 		D2L.Performance.measure('d2l.page.domContentLoadedHandlers', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
 		D2L.Performance.measure('d2l.page.load', 'fetchStart', 'loadEventStart');
-
-	}
-
-	function check() {
-		if (!pageReady) {
-			return;
-		}
-		D2L.Performance.measure('d2l.page.display', 'fetchStart');
-		document.body.classList.remove('d2l-page-loading');
-		logMeasures();
-	}
-
-	function pageIsReady() {
-
-		if (pageReady) {
-			return;
-		}
-
-		pageReady = true;
-		check();
-
-	}
-
-	addEventListener('load', function() {
-		pageLoaded = true;
-		logMeasures();
 	});
 
+	// polyfill in use
 	if (window.WebComponents) {
-		addEventListener('WebComponentsReady', function() {
-			D2L.Performance.measure('d2l.page.webComponentsReady', 'fetchStart');
-			pageIsReady();
-		});
+		addEventListener('WebComponentsReady', pageIsReady);
 	} else {
 		if (document.readyState === 'interactive' || document.readyState === 'complete') {
 			pageIsReady();

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -11,7 +11,7 @@
 
 		D2L.Performance.measure('d2l.page.preFetch', 'navigationStart', 'fetchStart');
 		D2L.Performance.measure('d2l.page.domInteractive', 'fetchStart', 'domInteractive');
-		D2L.Performance.measure('d2l.page.domContentLoaded', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
+		D2L.Performance.measure('d2l.page.domContentLoadedHandlers', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
 		D2L.Performance.measure('d2l.page.load', 'fetchStart', 'loadEventStart');
 
 	}


### PR DESCRIPTION
Simplifying how the page-loading code works:
- since navigation is now not a dependency on fading the page in, removing all references to it
- renaming the `domContentLoaded` measure to `domContentLoadedHandlers` to more accurately reflect its purpose
- logging the performance measures in the `onload` callback, since waiting for the `pageReady` isn't necessary
- no longer measuring the `webComponentsReady` event since it always corresponds to the `page.display` event anyway, and in cases where the polyfill wasn't required (Chrome), it wasn't getting logged at all.

@dbatiste thoughts?