### PR TITLE
moving over the “no login” navigation and shared components

### DIFF
--- a/src/bsi.scss
+++ b/src/bsi.scss
@@ -8,6 +8,7 @@
 @import 'image-link.scss';
 @import 'links.scss';
 @import 'list.scss';
+@import 'navigation/index.scss';
 @import 'page.scss';
 @import 'page-loading/page-loading.scss';
 @import 'page-two-column.scss';

--- a/src/navigation/common.scss
+++ b/src/navigation/common.scss
@@ -1,0 +1,23 @@
+$d2l-navigation-header-height: 90px;
+$d2l-navigation-header-height-mobile: 72px;
+
+.d2l-navigation-s-band-color {
+	height: 4px;
+}
+
+.d2l-navigation-s-centerer {
+	margin: 0 auto;
+	max-width: 1230px;
+}
+
+.d2l-navigation-s-gutters {
+	padding-left: 2.439%;
+	padding-right: 2.439%;
+}
+
+@media(max-width: 615px) {
+	.d2l-navigation-s-gutters {
+		padding-left: 15px;
+		padding-right: 15px;
+	}
+}

--- a/src/navigation/index.scss
+++ b/src/navigation/index.scss
@@ -1,0 +1,3 @@
+@import 'common.scss';
+@import 'no-login.scss';
+@import 'shadow.scss';

--- a/src/navigation/no-login.scss
+++ b/src/navigation/no-login.scss
@@ -1,0 +1,33 @@
+@import '../../bower_components/d2l-colors/d2l-colors.scss';
+
+.d2l-navigation-s-no-login {
+	background-color: #fff;
+	border-bottom: 1px solid $d2l-color-gypsum;
+	line-height: 1;
+	min-width: 320px;
+	position: relative;
+}
+
+.d2l-navigation-s-no-login-header-container {
+	-webkit-align-items: center;
+	-ms-flex-align: center;
+	align-items: center;
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+	height: $d2l-navigation-header-height;
+}
+
+.d2l-navigation-s-no-login-logo {
+	-ms-flex: 0 1 auto;
+	-webkit-flex: 0 1 auto;
+	border: none; /* needed for IE10 */
+	flex: 0 1 auto;
+	max-height: 60px;
+	max-width: 260px;
+}
+@media(max-width: 615px) {
+	.d2l-navigation-s-no-login-header-container {
+		height: $d2l-navigation-header-height-mobile;
+	}
+}

--- a/src/navigation/shadow.scss
+++ b/src/navigation/shadow.scss
@@ -1,0 +1,20 @@
+.d2l-navigation-s-shadow-drop-border {
+	background-color: rgba(0,0,0,0.02);
+	bottom: -4px;
+	height: 4px;
+	pointer-events: none;
+	position: absolute;
+	width: 100%;
+	z-index: 100;
+}
+.d2l-navigation-s-shadow-gradient {
+	background: -moz-linear-gradient(top,  rgba(249,250,251,1) 0%, rgba(249,250,251,0) 100%);
+	background: -webkit-linear-gradient(top,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
+	background: linear-gradient(to bottom,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
+	bottom: -150px;
+	height: 150px;
+	width: 100%;
+	pointer-events: none;
+	position: absolute;
+	z-index: -100;
+}


### PR DESCRIPTION
@dbatiste This is the required CSS from the client-side navigation just to render the "no login" version of the navbar, which is going to be the first server-side rendering experiment (PR in platformTools to follow).