### PR TITLE
remove page-loading fade-in

### DIFF
--- a/src/bsi.scss
+++ b/src/bsi.scss
@@ -10,7 +10,6 @@
 @import 'list.scss';
 @import 'navigation/index.scss';
 @import 'page.scss';
-@import 'page-loading/page-loading.scss';
 @import 'page-two-column.scss';
 @import 'page-two-panel-selector.scss';
 @import 'dialog.scss';

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -9,7 +9,6 @@
 		}
 		pageReady = true;
 		D2L.Performance.measure('d2l.page.display', 'fetchStart');
-		document.body.classList.remove('d2l-page-loading');
 	}
 
 	addEventListener('load', function() {

--- a/src/page-loading/page-loading.scss
+++ b/src/page-loading/page-loading.scss
@@ -1,7 +1,0 @@
-body > * {
-	transition: opacity ease-in .2s;
-}
-
-body.d2l-page-loading > *:not(.d2l-page-loading-skip) {
-	opacity: 0;
-}


### PR DESCRIPTION
@dbatiste look OK? This CSS along with the `d2l-page-loading` class is no longer needed now that we're not waiting for the navigation to load before fading the page in. Instead, we can rely on the `unresolved` attribute on the body, which Polymer will remove for us and supply the opacity CSS.

I'll make a PR in platformTools to remove the class names and update BSI.