### PR TITLE
Fix scrolling inside <dialog-iframe> for mobile version of Safari

### DIFF
--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -81,6 +81,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	@include flex-grow(2);
 	overflow: auto;
 	position: relative;
+	-webkit-overflow-scrolling: touch;
 }
 
 .d2l-dialog-flex {


### PR DESCRIPTION
[see](https://trello.com/c/ozOZHi45/122-bug-ios-prod-can-t-scroll-versioning-list) for the additional description