### PR TITLE
reduce title size to 25px

### DIFF
--- a/src/navigation/header.scss
+++ b/src/navigation/header.scss
@@ -58,7 +58,7 @@
 
 .d2l-navigation-s-header-logo-area > .d2l-navigation-s-link {
 	display: block;
-	font-size: 25px;
+	font-size: 1.25rem;
 	-ms-flex: 0 1 auto;
 	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto; /* IE10 defaults to 0 0 auto */

--- a/src/navigation/header.scss
+++ b/src/navigation/header.scss
@@ -58,7 +58,7 @@
 
 .d2l-navigation-s-header-logo-area > .d2l-navigation-s-link {
 	display: block;
-	font-size: 1.5rem;
+	font-size: 25px;
 	-ms-flex: 0 1 auto;
 	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto; /* IE10 defaults to 0 0 auto */


### PR DESCRIPTION
It seems that we don't have to add another css class for it since the reduced title is applied whenever a title is present at header-logo-area.