### PR TITLE
US81437: d2l-alert factored into its own component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "brightspace-integration",
   "dependencies": {
+	"d2l-alert":"https://github.com/Brightspace/alert.git#0.0.1",
     "d2l-button": "^3.0.8",
     "d2l-button-group": "^0.4.6",
     "d2l-colors": "^2.2.3",

--- a/bsi.html
+++ b/bsi.html
@@ -1,6 +1,7 @@
 <script src="src/page-loading/page-loading.js"></script>
 
 <link rel="import" href="bsi-style.html">
+<link rel="import" href="../d2l-alert/d2l-alert.html">
 <link rel="import" href="../d2l-button/d2l-button.html">
 <link rel="import" href="../d2l-button/d2l-floating-buttons.html">
 <link rel="import" href="../d2l-button-group/d2l-button-group.html">


### PR DESCRIPTION
Acceptance Criteria:

d2l-alert lives independently from d2l-my-courses-ui as a Polymer web component
d2l-my-courses-ui is refactored to use d2l-alert as a dependency
nothing breaks

d2l-alert now lives here: https://github.com/Brightspace/alert

Intention is to someday move it to BrightspaceUI