### PR TITLE
setting color of icon when active in addition to text

### DIFF
--- a/src/navigation/highlight-icon.scss
+++ b/src/navigation/highlight-icon.scss
@@ -28,7 +28,8 @@ button.d2l-navigation-s-button-highlight:focus,
 	outline-style: none;
 }
 
-button.d2l-navigation-s-button-highlight[data-active] {
+button.d2l-navigation-s-button-highlight[data-active],
+button.d2l-navigation-s-button-highlight[data-active] d2l-icon {
 	color: $d2l-color-celestine;
 }
 


### PR DESCRIPTION
The bar and text were getting the active color when menus were open, but the icon wasn't. This fixes DE23968.