### PR TITLE
bump d2l-my-courses to 0.25.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "d2l-loading-spinner": "^4.0.2",
     "d2l-menu": "^0.2.8",
     "d2l-more-less": "^1.0.6",
-    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.24.0",
+    "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#0.25.0",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.14.21",
     "d2l-offscreen": "^2.2.3",
     "d2l-performance": "^0.0.4",


### PR DESCRIPTION
prevents problems arising from mismatched d2l-alert states!

@omsmith 