### PR TITLE
Fixing positioning of mobile menu in rtl on firefox

### DIFF
--- a/src/navigation/mobile-menu.scss
+++ b/src/navigation/mobile-menu.scss
@@ -18,6 +18,7 @@
 }
 
 [dir='rtl'] .d2l-navigation-s-mobile-menu-content {
+	left: auto;
 	right: 0;
 	transform: translateX(100%);
 }


### PR DESCRIPTION
Firefox was choosing to use left:0 over right: 0 with RTL on.