### PR TITLE
Provide CSS for unmeasured nav items for iOS Safari chomping.

### DIFF
--- a/src/navigation/main.scss
+++ b/src/navigation/main.scss
@@ -23,6 +23,11 @@
 	&[data-loading] {
 		opacity: 0;
 	}
+	&[data-unmeasured] {
+		-webkit-flex-wrap: wrap;
+		-ms-flex-wrap: wrap;
+		flex-wrap: wrap;
+	}
 }
 
 .d2l-navigation-s-item {


### PR DESCRIPTION
This change adds `flex-wrap: wrap` CSS for nav links flex container so that browsers (namely Safari on iOS) can measure dimensions unsquished (yes, that is a technical term... ;)  ).  

With the exception of IE, always allowing wrapping works fine because we hide links that won't fit before the browser has had a chance to wrap them.  When chomping in IE (ex. via resizing), the links wrap and then disappear, resulting in bumping effect.  To remedy this, we will still apply `flex-wrap: nowrap` after measurements are made.

There will be a corresponding PR in LMS to add/remove the `data-unmeasured` attribute.  Alternatively, we may be able to piggyback on existing `data-loading` attribute.