### PR TITLE
Set display:none for mobile nav menu in closed state

### DIFF
--- a/src/navigation/mobile-menu.scss
+++ b/src/navigation/mobile-menu.scss
@@ -1,6 +1,10 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 @import 'common.scss';
 
+.d2l-navigation-s-mobile-menu[data-state="closed"] {
+	display: none;
+}
+
 .d2l-navigation-s-mobile-menu-content {
 	background-color: $d2l-color-white;
 	border-top: 4px solid $d2l-color-pressicus;

--- a/src/navigation/mobile-menu.scss
+++ b/src/navigation/mobile-menu.scss
@@ -8,7 +8,6 @@
 .d2l-navigation-s-mobile-menu-content {
 	background-color: $d2l-color-white;
 	border-top: 4px solid $d2l-color-pressicus;
-	display: block;
 	height: 100%;
 	left: 0;
 	min-width: 300px;

--- a/src/navigation/mobile-menu.scss
+++ b/src/navigation/mobile-menu.scss
@@ -8,7 +8,7 @@
 .d2l-navigation-s-mobile-menu-content {
 	background-color: $d2l-color-white;
 	border-top: 4px solid $d2l-color-pressicus;
-	display: none;
+	display: block;
 	height: 100%;
 	left: 0;
 	min-width: 300px;
@@ -25,11 +25,6 @@
 	left: auto;
 	right: 0;
 	transform: translateX(100%);
-}
-
-.d2l-navigation-s-mobile-menu[data-state="transition"] .d2l-navigation-s-mobile-menu-content,
-.d2l-navigation-s-mobile-menu[data-state="opened"] .d2l-navigation-s-mobile-menu-content {
-	display: block;
 }
 
 .d2l-navigation-s-mobile-menu[data-state="opened"] .d2l-navigation-s-mobile-menu-content {


### PR DESCRIPTION
This change is being made to prevent tabbing to mobile flyout children when in the closed state.