### PR TITLE
US81575 - Adding html-editor icon for TinyMCE a11ychecker plugin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "d2l-button-group": "^0.5.0",
     "d2l-colors": "^2.2.3",
     "d2l-dropdown": "^5.0.3",
-    "d2l-icons": "^3.0.0",
+    "d2l-icons": "^3.1.0",
     "d2l-image-action": "^0.7.0",
     "d2l-link": "^3.3.1",
     "d2l-loading-spinner": "^5.0.3",


### PR DESCRIPTION
Updating d2l-icons to v3.1.0, which contains the new html-editor icon for the TinyMCE a11ychecker plugin.