### PR TITLE
smaller bsi.js bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "autoprefix": "postcss -c postcss.config.json",
     "prebuild": "rimraf dist && mkdir dist",
     "build": "npm run build:js && npm run build:sass && npm run build:icons && npm run build:wc",
-    "build:js": "browserify -g uglifyify ./src/index.js > ./dist/bsi.js",
+    "build:js": "rollup -c -- ./src/index.js > ./dist/bsi.js",
     "postbuild:js": "npm run uglify:js",
     "build:sass": "node-sass --output-style expanded ./src/bsi.scss ./dist/bsi.css && node-sass --output-style expanded ./src/datagrid/datagrid.scss ./dist/datagrid.css",
     "postbuild:sass": "npm run autoprefix && npm run uglify:css",
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",
-    "browserify": "^13.1.0",
     "clean-css": "^3.4.19",
     "cpy-cli": "^1.0.1",
     "d2l-intl": "^0.3.2",
@@ -58,8 +57,11 @@
     "node-sass": "^3.10.1",
     "postcss-cli": "^2.6.0",
     "rimraf": "^2.5.4",
+    "rollup": "^0.41.4",
+    "rollup-plugin-commonjs": "^7.0.0",
+    "rollup-plugin-json": "^2.1.0",
+    "rollup-plugin-node-resolve": "^2.0.0",
     "uglify-js": "^2.7.3",
-    "uglifyify": "^3.0.2",
     "web-component-shards": "^1.1.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,13 @@
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+	plugins: [
+		commonjs(),
+		json(),
+		resolve()
+	],
+	format: 'iife',
+	moduleName: 'BSI'
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,16 @@
 'use strict';
 
-require('../node_modules/lie/dist/lie.polyfill.min.js');
-require('../bower_components/d2l-performance/d2l-performance.js');
-require('../bower_components/jquery-vui-accordion/accordion.js');
-require('../bower_components/jquery-vui-change-tracking/changeTracker.js');
-require('../bower_components/jquery-vui-change-tracking/changeTracking.js');
-require('../bower_components/jquery-vui-collapsible-section/collapsibleSection.js');
-require('../bower_components/jquery-vui-more-less/moreLess.js');
-require('../bower_components/jquery-vui-scrollspy/scroll-spy.js');
-require('../bower_components/d2l-telemetry/d2l-telemetry.js');
-require('./page-loading/page-loading.js');
+import '../node_modules/lie/lib/browser';
+import '../bower_components/d2l-performance/d2l-performance.js';
+import '../bower_components/jquery-vui-accordion/accordion.js';
+import '../bower_components/jquery-vui-change-tracking/changeTracker.js';
+import '../bower_components/jquery-vui-change-tracking/changeTracking.js';
+import '../bower_components/jquery-vui-collapsible-section/collapsibleSection.js';
+import '../bower_components/jquery-vui-more-less/moreLess.js';
+import '../bower_components/jquery-vui-scrollspy/scroll-spy.js';
+import '../bower_components/d2l-telemetry/d2l-telemetry.js';
+import './page-loading/page-loading.js';
 
+import d2lIntl from 'd2l-intl';
 window.BSI = window.BSI || {};
-window.BSI.Intl = require('d2l-intl');
+window.BSI.Intl = d2lIntl;

--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -1,11 +1,8 @@
-(function() {
-	'use strict';
+'use strict';
 
-	addEventListener('load', function() {
-		D2L.Performance.measure('d2l.page.preFetch', 'navigationStart', 'fetchStart');
-		D2L.Performance.measure('d2l.page.domInteractive', 'fetchStart', 'domInteractive');
-		D2L.Performance.measure('d2l.page.domContentLoadedHandlers', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
-		D2L.Performance.measure('d2l.page.load', 'fetchStart', 'loadEventStart');
-	});
-
-})();
+addEventListener('load', function() {
+	D2L.Performance.measure('d2l.page.preFetch', 'navigationStart', 'fetchStart');
+	D2L.Performance.measure('d2l.page.domInteractive', 'fetchStart', 'domInteractive');
+	D2L.Performance.measure('d2l.page.domContentLoadedHandlers', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
+	D2L.Performance.measure('d2l.page.load', 'fetchStart', 'loadEventStart');
+});


### PR DESCRIPTION
Minified file is smaller by about 7K

* don't use the pre-minified lie bundle
* remove unnecessary wrapper around page-loading
* bundle scripts with rollup, less boilerplate than the browerify bundle