### PR TITLE
Fix jsonp match

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "uglify:html": "./node_modules/.bin/html-minifier -c html-minifier.conf --input-dir tmp-wc --output-dir dist",
     "postuglify:html": "rimraf tmp-wc",
     "uglify:js": "uglifyjs ./dist/bsi.js --compress --mangle -o ./dist/bsi.min.js",
-    "jsonpify-imports": "node jsonp-imports.js ./dist/*.html"
+    "jsonpify-imports": "node jsonp-imports.js './dist/*.html'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Was only ever matching the first file, meaning we were only getting bsi.html.js, not the rest of them. Introduced in https://github.com/Brightspace/brightspace-integration/commit/d16d58cbd21dee24c645c24829b079035fee6117 to fix this exact problem, seemingly.