### PR TITLE
Don't ignore bower_components on v10.6.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bower_components
 dist/
 node_modules/
 .idea/


### PR DESCRIPTION
Since we're committing bower_components on this branch, this will ensure that changes to bower_components aren't missed - and, perhaps just as importantly, will make it blatantly obvious if more changes occurred than intended.