### PR TITLE
Fix jsonpify-imports script to work on all envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "uglify:html": "./node_modules/.bin/html-minifier -c html-minifier.conf --input-dir tmp-wc --output-dir dist",
     "postuglify:html": "rimraf tmp-wc",
     "uglify:js": "uglifyjs ./dist/bsi.js --compress --mangle -o ./dist/bsi.min.js",
-    "jsonpify-imports": "node jsonp-imports.js './dist/*.html'"
+    "jsonpify-imports": "node jsonp-imports.js \"./dist/*.html\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This works (for me, at least) on Windows and WSL, would love for someone to give it a try on Linux and if it works there too lets merge it in. I'd love to get me some bsi.html.js in my dist folder again :)