### PR TITLE
new timings

### DIFF
--- a/src/page-loading/page-loading.js
+++ b/src/page-loading/page-loading.js
@@ -6,6 +6,8 @@
 		D2L.Performance.measure('d2l.page.domInteractive', 'fetchStart', 'domInteractive');
 		D2L.Performance.measure('d2l.page.domContentLoadedHandlers', 'domContentLoadedEventStart', 'domContentLoadedEventEnd');
 		D2L.Performance.measure('d2l.page.load', 'fetchStart', 'loadEventStart');
+		D2L.Performance.measure('d2l.page.server', 'requestStart', 'responseStart');
+		D2L.Performance.measure('d2l.page.download', 'responseStart', 'responseEnd');
 	});
 
 })();

--- a/src/page-loading/web-components-ready.js
+++ b/src/page-loading/web-components-ready.js
@@ -8,6 +8,7 @@
 			return;
 		}
 		pageReady = true;
+		D2L.Performance.measure('d2l.page.visible', 'responseEnd');
 		D2L.Performance.measure('d2l.page.display', 'fetchStart');
 	}
 


### PR DESCRIPTION
Adding some new user timings:
- "server": captures time spent on the server processing the request (fetchStart -> responseStart)
- "download": time spent downloading the response (responseStart -> responseEnd)
- "visible": very similar to "display" (and may replace it) except it excludes the time spent on the server and downloading (responseEnd -> webComponentReady). This helps us isolate client-side performance improvements from variation in server time / download time.

In testing, I found that generally: display = server + download + visible. That to me indicates that there isn't much overlap between those events -- i.e. that the browser isn't doing a lot of processing of the document until it's fully downloaded. That may change for large documents, but it's what I was seeing.

I'm going to adjust the code in the LE that sends these along to Google Analytics such that it includes the new "visible" timing. Eventually we may phase out "display" although it's kind of handy that it includes all 3.