### PR TITLE
vendor prefixes aren’t needed as they’re added automatically by autoprefixer

### DIFF
--- a/src/navigation/admin-menu.scss
+++ b/src/navigation/admin-menu.scss
@@ -1,7 +1,5 @@
 .d2l-navigation-s-admin-menu {
 	display: inline-block;
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	height: 100%;
 }

--- a/src/navigation/common.scss
+++ b/src/navigation/common.scss
@@ -21,11 +21,7 @@ $d2l-navigation-bp-title: 670px;
 }
 
 .d2l-navigation-s-header-container {
-	-webkit-align-items: center;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	height: $d2l-navigation-header-height;
 }

--- a/src/navigation/divider.scss
+++ b/src/navigation/divider.scss
@@ -2,8 +2,6 @@
 
 .d2l-navigation-s-divider {
 	display: inline-block;
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	margin: 0 9px;
 	d2l-icon {

--- a/src/navigation/header-course.scss
+++ b/src/navigation/header-course.scss
@@ -1,11 +1,5 @@
 .d2l-navigation-s-header-course {
-	-webkit-flex: 0 1 auto;
-	-webkit-align-items: center;
-	-ms-flex: 0 1 auto;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	flex: 0 1 auto;
 	height: 100%;
@@ -17,8 +11,6 @@
 .d2l-navigation-s-header-course > .d2l-navigation-s-link {
 	display: block;
 	font-size: 1.5rem;
-	-ms-flex: 0 1 auto;
-	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto; /* IE10 defaults to 0 0 auto */
 	overflow: hidden;
 	line-height: normal;

--- a/src/navigation/header.scss
+++ b/src/navigation/header.scss
@@ -6,29 +6,19 @@
 
 .d2l-navigation-s-gutter {
 	display: inline-block;
-	-ms-flex: 1 1 auto;
-	-webkit-flex: 1 1 auto;
 	flex: 1 1 auto;
 	min-width: 30px;
 }
 
 .d2l-navigation-s-header-actions {
-	-webkit-align-items: center;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	height: 100%;
 }
 
 .d2l-navigation-s-header-open-button-wrapper {
 	display: inline-block;
-	-ms-flex: 0 1 auto;
-	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto;
 	height: 100%;
 	@media (min-width: $d2l-navigation-bp-mobile-menu) {
@@ -37,13 +27,7 @@
 }
 
 .d2l-navigation-s-header-logo-area {
-	-webkit-flex: 0 1 auto;
-	-webkit-align-items: center;
-	-ms-flex: 0 1 auto;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	flex: 0 1 auto;
 	height: 100%;
@@ -78,8 +62,6 @@
 .d2l-navigation-s-header-logo-area > .d2l-navigation-s-link {
 	display: block;
 	font-size: 1.5rem;
-	-ms-flex: 0 1 auto;
-	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto; /* IE10 defaults to 0 0 auto */
 	overflow: hidden;
 	line-height: normal;

--- a/src/navigation/highlight-icon.scss
+++ b/src/navigation/highlight-icon.scss
@@ -1,15 +1,11 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-navigation-s-button-highlight {
-	-webkit-align-items: center;
-	-ms-flex-align: center;
 	align-items: center;
 	background-color: $d2l-color-white;
 	border: none;
 	color: $d2l-color-ferrite;
 	cursor: pointer;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	font-family: inherit;
 	font-size: 0.7rem;
@@ -34,8 +30,6 @@ button.d2l-navigation-s-button-highlight[data-active] d2l-icon {
 }
 
 .d2l-navigation-s-button-highlight d2l-icon {
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 }
 

--- a/src/navigation/main.scss
+++ b/src/navigation/main.scss
@@ -5,20 +5,14 @@
 }
 
 .d2l-navigation-s-main-wrapper {
-	-webkit-align-items: center;
-	-ms-align-items: center;
 	align-items: center;
 	display: -ms-flexbox;
 	display: -webkit-flex;
 	display: flex;
 	height: calc(1rem + 40px);
-	-webkit-flex-wrap: nowrap;
-	-ms-flex-wrap: nowrap;
 	flex-wrap: nowrap;
 	transition: opacity ease-in 0.2s;
 	&[data-more] {
-		-webkit-justify-content: space-between;
-		-ms-align-justify-content: space-between;
 		justify-content: space-between;
 	}
 	&[data-loading] {

--- a/src/navigation/mobile-menu.scss
+++ b/src/navigation/mobile-menu.scss
@@ -66,8 +66,6 @@
 .d2l-navigation-s-mobile-menu-header {
 	align-items: center;
 	border-bottom: 1px solid $d2l-color-gypsum;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	height: $d2l-navigation-header-height;
 	padding: 0 1rem;
@@ -79,11 +77,7 @@
 }
 
 .d2l-navigation-s-mobile-menu-org-header {
-	-webkit-box-align: center;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	height: 100%;
 	width: 100%;
@@ -102,11 +96,7 @@
 
 .d2l-navigation-s-mobile-menu-course-header,
 .d2l-navigation-s-mobile-menu-branded-header {
-	-webkit-box-align: center;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	height: 100%;
 	width: 100%;
@@ -127,8 +117,6 @@
 }
 
 .d2l-navigation-s-mobile-menu-header-course-menu {
-	-webkit-box-align: center;
-	-ms-flex-align: center;
 	align-items: center;
 	display: none;
 	width: 100%;
@@ -151,8 +139,6 @@
 
 .d2l-navigation-s-mobile-menu.d2l-navigation-s-mobile-menu-show-course-menu {
 	.d2l-navigation-s-mobile-menu-header-course-menu {
-		display: -ms-flexbox;
-		display: -webkit-flex;
 		display: flex;
 	}
 	.d2l-navigation-s-mobile-menu-course-menu {
@@ -189,8 +175,6 @@
 }
 
 .d2l-navigation-s-mobile-menu-header .d2l-navigation-s-header-logo-area {
-	-webkit-flex-grow: 1;
-	-ms-flex-grow: 1;
 	flex-grow: 1;
 
 	&.d2l-navigation-s-header-no-home-icon .d2l-navigation-s-logo-divider {

--- a/src/navigation/personal-menu.scss
+++ b/src/navigation/personal-menu.scss
@@ -3,25 +3,17 @@
 
 .d2l-navigation-s-personal-menu {
 	display: inline-block;
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	height: 100%;
 }
 
 .d2l-navigation-s-personal-menu-wrapper {
-	-webkit-align-items: center;
-	-ms-flex-align: center;
 	align-items: center;
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 }
 
 .d2l-navigation-s-personal-menu-wrapper d2l-icon {
 	border-radius: 8px;
-	-ms-flex: 0 0 auto;
-	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	height: 42px;
 	overflow: hidden;
@@ -29,8 +21,6 @@
 }
 
 .d2l-navigation-s-personal-menu-text {
-	-ms-flex: 0 1 auto;
-	-webkit-flex: 0 1 auto;
 	flex: 0 1 auto;
 	margin-left: 10px;
 	max-width: 200px;

--- a/src/navigation/shadow.scss
+++ b/src/navigation/shadow.scss
@@ -8,8 +8,6 @@
 	z-index: 100;
 }
 .d2l-navigation-s-shadow-gradient {
-	background: -moz-linear-gradient(top,  rgba(249,250,251,1) 0%, rgba(249,250,251,0) 100%);
-	background: -webkit-linear-gradient(top,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
 	background: linear-gradient(to bottom,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
 	bottom: -150px;
 	height: 150px;


### PR DESCRIPTION
Confirmed this results in the same output CSS by doing a side-by-side diff.