### PR TITLE
making the “d2l.page.visible” timing visible on the page if asked for it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
     "node": true
   },
   "rules": {
-      "strict": 2
+      "strict": 2,
+      "no-empty": ["error", { "allowEmptyCatch": true }]
   },
   "globals": {
     "D2L": true

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ require('../bower_components/jquery-vui-more-less/moreLess.js');
 require('../bower_components/jquery-vui-scrollspy/scroll-spy.js');
 require('../bower_components/d2l-telemetry/d2l-telemetry.js');
 require('./page-loading/page-loading.js');
+require('./page-loading/timing-debug.js');
 
 window.BSI = window.BSI || {};
 window.BSI.Intl = require('d2l-intl');

--- a/src/page-loading/timing-debug.js
+++ b/src/page-loading/timing-debug.js
@@ -1,0 +1,44 @@
+(function() {
+	'use strict';
+
+	window.addEventListener('D2LPerformanceMeasure', function addTiming(e) {
+
+		if (e.detail.value.name !== 'd2l.page.visible') {
+			return;
+		}
+
+		window.removeEventListener( 'D2LPerformanceMeasure', addTiming );
+
+		var res = /(\?|&)timingdebug=(1|0)/gi.exec(location.search);
+		if ( res !== null && res.length === 3 ) {
+			var timingVal = (res[2] === '0') ? false : true;
+			try {
+				if (timingVal) {
+					window.sessionStorage.setItem('TimingDebug', '1');
+				} else {
+					window.sessionStorage.removeItem('TimingDebug');
+				}
+			} catch (e) {}
+		}
+
+		var timingDebug = false;
+		try {
+			timingDebug = (window.sessionStorage.getItem('TimingDebug') !== null);
+		} catch (e) {}
+
+		if (!timingDebug) {
+			return;
+		}
+
+		requestAnimationFrame(function() {
+			var div = document.createElement('div');
+			div.className = 'd2l-page-timing';
+			div.appendChild(
+				document.createTextNode('Visible: ' + D2L.Performance.timing['d2l.page.visible'])
+			);
+			document.body.appendChild(div);
+		});
+
+	});
+
+})();

--- a/src/page.scss
+++ b/src/page.scss
@@ -66,3 +66,10 @@ body[unresolved] {
 .d2l-page-header {
 	margin-bottom: 1.5rem;
 }
+
+.d2l-page-timing {
+	font-size: 0.7rem;
+	left: 10px;
+	position: fixed;
+	top: 10px;
+}


### PR DESCRIPTION
@dbatiste, @omsmith What do you guys think? This would let us not need to keep opening up the console to get at the timing variable values when doing manual performance tests... which will be especially handy in Edge since the console leaks like a sieve.

How it works: you just need to put this in the URL bar and visit any page `&timingdebug=1`. That'll store in session storage that you want to see the "d2l.page.visible" timing variable output to the page for every page visit. To stop showing it, either add `&timingdebug=0` or remove it manually from session storage.

It looks like this, just kind of floating there:

![screen shot 2017-03-03 at 6 32 37 pm](https://cloud.githubusercontent.com/assets/5491151/23572836/d7762942-003f-11e7-974c-4fb4ae2d99d4.png)


