### PR TITLE
Update autoprofix config to reflect current browser support.

### DIFF
--- a/postcss.config.json
+++ b/postcss.config.json
@@ -3,6 +3,6 @@
 	"input": "./dist/bsi.css",
 	"dir": "./dist/",
 	"autoprefixer": {
-		"browsers": "Last 1 versions, Firefox ESR, IE >= 11"
+		"browsers": "Last 3 versions, Firefox ESR, IE >= 11, Safari >= 9"
 	}
 }

--- a/postcss.config.json
+++ b/postcss.config.json
@@ -3,6 +3,6 @@
 	"input": "./dist/bsi.css",
 	"dir": "./dist/",
 	"autoprefixer": {
-		"browsers": "Last 4 versions, Firefox ESR, IE >= 9, Safari >= 6"
+		"browsers": "Last 1 versions, Firefox ESR, IE >= 11"
 	}
 }


### PR DESCRIPTION
I _think_ this is what we want.

To give an idea of the raw size change:
```
bsi.css          111KB -> 97KB (-12.6%)
bsi.min.css      89KB -> 79KB (-11.2%)
```
