### PR TITLE
DE24640: adjusting the responsive rules so the logo doesn't get cut off

### DIFF
--- a/src/navigation/common.scss
+++ b/src/navigation/common.scss
@@ -8,7 +8,7 @@ $d2l-navigation-small-logo-width: 173px;
 $d2l-navigation-bp-mobile-menu: 992px;
 $d2l-navigation-bp-mobile-menu-medium: 615px;
 $d2l-navigation-bp-mobile-menu-small: 380px;
-$d2l-navigation-bp-title: 670px;
+$d2l-navigation-bp-title: 714px;
 
 .d2l-navigation-s-centerer {
 	margin: 0 auto;


### PR DESCRIPTION
Demonstration of the bug:

![navbar logo cut off](https://cloud.githubusercontent.com/assets/5491151/23877094/09fe3146-0817-11e7-9d74-25f91ce264eb.jpg)

Width of all the elements in the navbar at this viewport size from left to right:
30 (hamburger) + 42 (separator) + 260 (logo) + 30 (spacing) + 40 (course menu) + 42 (separator) + 160 (notifications) + 42 (separator) + 42 (personal menu) + gutters (2.44% = ~33) - 7 (negative margins on the logo) = **714px**.

So that means that at ~714px, with a logo that takes up the full max-width of 260, the logo starts to get cut off -- and it does. So the responsive rule to hide the logo should kick in at 714 instead of 670.