### PR TITLE
replacing the usage of sass-flex-mixins with just normal flex box CSS…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "jquery-vui-more-less": "^1.2.0",
     "jquery-vui-scrollspy": "~0.2.0",
     "polymer": "^1.7.0",
-    "sass-flex-mixin": "^1.0.3",
     "vui-breadcrumbs": "^2.1.0",
     "vui-dropdown": "^0.9.1",
     "vui-field": "^1.3.0",

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -78,7 +78,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 }
 
 .d2l-dialog-body {
-	@include flex-grow(2);
+	flex-grow: 2;
 	overflow: auto;
 	position: relative;
 	-webkit-overflow-scrolling: touch;
@@ -86,8 +86,8 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 
 .d2l-dialog-flex {
 	box-sizing: border-box;
-	@include flexbox;
-	@include flex-direction(column);
+	display: flex;
+	flex-direction: column;
 	height: 100%;
 	width: 100% !important;
 	position: absolute;
@@ -96,7 +96,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 
 .d2l-dialog-flex > .d2l-dialog-footer,
 .d2l-dialog-flex > .d2l-dialog-footer-container {
-	@include align-self(flex-end);
+	align-self: flex-end;
 	width: 100%;
 }
 
@@ -121,7 +121,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 }
 
 .d2l-dialog-title {
-	@include align-self(flex-start);
+	align-self: flex-start;
 	position: relative;
 	width: 100%;
 	margin: -0.25rem 0.25rem 0.25rem 0;
@@ -303,23 +303,23 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	}
 
 	.ddial_o2 {
-		@include flexbox;
-		@include flex-direction(column);
+		display: flex;
+		flex-direction: column;
 	}
 
 	.ddial_i {
-		@include flexbox;
-		@include flex-direction(column);
-		@include flex-grow(1);
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
 	}
 
 	.ddial_c {
-		@include flexbox;
-		@include flex-grow(1);
-		@include flex-direction(column);
+		display: flex;
+		flex-grow: 1;
+		flex-direction: column;
 	}
 
 	.ddial_c_frame {
-		@include flex-grow(1);
+		flex-grow: 1;
 	}
 }

--- a/src/vui.scss
+++ b/src/vui.scss
@@ -13,4 +13,3 @@
 @import '../bower_components/vui-input/input.css.scss';
 @import './deprecated/offscreen.scss';
 @import '../bower_components/vui-validation/validation.css.scss';
-@import '../bower_components/sass-flex-mixin/_flex.scss';


### PR DESCRIPTION
… because it doesn’t require documentation to understand and we get the prefixes elsewhere anyway