### PR TITLE
reintroducing d2l-link class

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "d2l-fastdom-import": "https://github.com/Brightspace/fastdom-import.git#v1.0.2",
     "d2l-icons": "^3.1.0",
     "d2l-image-action": "^1.0.0",
-    "d2l-link": "^3.3.1",
+    "d2l-link": "^3.5.0",
     "d2l-loading-spinner": "^5.0.3",
     "d2l-menu": "^0.3.5",
     "d2l-more-less": "^2.2.0",

--- a/sass/deprecated/link.scss
+++ b/sass/deprecated/link.scss
@@ -1,33 +1,12 @@
-@import '../../bower_components/d2l-colors/d2l-colors.scss';
+@import '../../bower_components/d2l-link/d2l-link.scss';
 
-/* these are still referenced by a few FRAs */
-
-@mixin _vui-link-focus() {
-	color: $d2l-color-celestuba;
-	text-decoration: underline;
-	outline-width: 0;
-}
-
-@mixin _vui-link($font-weight: 400) {
-	&,
-	&:visited,
-	&:link,
-	&:active {
-		color: $d2l-color-celestine;
-		font-weight: $font-weight;
-		text-decoration: none;
-		cursor: pointer;
-	}
-	&:hover,
-	&:focus {
-		@include _vui-link-focus;
-	}
-}
+/* these are still referenced by a few UMD FRAs */
 
 .vui-link {
-	@include _vui-link;
+	@include d2l-link();
 }
 
 .vui-link-main {
-	@include _vui-link($font-weight: 700);
+	@include d2l-link();
+	font-weight: 700;
 }

--- a/sass/html-block.scss
+++ b/sass/html-block.scss
@@ -1,4 +1,4 @@
-@import '../bower_components/d2l-colors/d2l-colors.scss';
+@import '../bower_components/d2l-link/d2l-link.scss';
 
 .d2l-typography .d2l-htmlblock {
 
@@ -103,18 +103,8 @@
 		list-style-type: square;
 	}
 
-	a,
-	a:visited {
-		color: $d2l-color-celestine;
-		cursor: pointer;
-		font-weight: normal;
-		text-decoration: none;
-	}
-
-	a:hover,
-	a:focus {
-		color: $d2l-color-celestuba;
-		text-decoration: underline;
+	a {
+		@include d2l-link();
 	}
 
 }

--- a/sass/links.scss
+++ b/sass/links.scss
@@ -1,6 +1,8 @@
 @import '../bower_components/d2l-colors/d2l-colors.scss';
+@import '../bower_components/d2l-link/d2l-link.scss';
 
-.d2l-link, .d2l-link:visited {
+.d2l-link {
+	@include d2l-link();
 	display: inline-block;
 }
 


### PR DESCRIPTION
I'll be switching the LMS over to use the "d2l-link" CSS class instead of the web component, as the performance gains are too significant right now to ignore.

This change pulls in the latest version of `d2l-link` -- which has Sass mixins now -- and applies the mixins to the `.d2l-link` CSS class and `.vui-link` class (for backwards compatibility with old FRAs). It also applies it inside HTML blocks for user-authored content.