### PR TITLE
fixing normal text colour on-hover

### DIFF
--- a/sass/button-menu.scss
+++ b/sass/button-menu.scss
@@ -40,6 +40,10 @@
 }
 
 .bsi-button-menu,
+.bsi-button-menu:hover,
+.bsi-button-menu:focus,
+.bsi-button-menu:visited,
+.bsi-button-menu:link,
 .bsi-button-menu.vui-disabled:hover,
 .bsi-button-menu.vui-disabled:focus {
 	background-color: $d2l-color-woolonardo;


### PR DESCRIPTION
@dbatiste Ended up being a specificity issue with the reset stylesheet's `:hover` effect.

From the reset:
```
a, a:hover {
    color: blue;
}
```

Original CSS for button-menu:
```
.bsi-button-menu {
   color: red;
}
```

`a:hover` ends up being more specific than `.bsi-button-menu`, so it wins. Must have been slightly different when this was coming from the web component style include -- probably only in shady DOM though.