### PR TITLE
Move to latest banner overlay release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "d2l-menu": "^0.3.5",
     "d2l-more-less": "^2.2.0",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#1.4.1",
-    "d2l-image-banner-overlay": "https://github.com/Brightspace/d2l-image-banner-overlay.git#^1.0.0",
+    "d2l-image-banner-overlay": "https://github.com/Brightspace/d2l-image-banner-overlay.git#^1.0.3",
     "d2l-navigation": "https://github.com/Brightspace/d2l-navigation-ui.git#0.15.2",
     "d2l-offscreen": "^2.2.5",
     "d2l-performance": "^0.0.4",


### PR DESCRIPTION
1.0.1 breaks in Safari < 10.1 and IE, and 1.0.2 breaks in everything so lets make sure we get 1.0.3 at a minimum