### PR TITLE
fixing right margins on context-menus

### DIFF
--- a/sass/context-menu.scss
+++ b/sass/context-menu.scss
@@ -50,11 +50,12 @@
 .dcm.dcm_handle.bsi-button-menu,
 .d2l-contextmenu-ph {
 	@include vui-dropdown-context-menu;
+}
+.dcm.dcm_handle.bsi-button-menu,
+.dcm.bsi-button-menu,
+.d2l-contextmenu-ph {
 	margin-left: 0.25rem;
-	[dir='rtl'] & {
-		margin-left: auto;
-		margin-right: 0.25rem;
-	}
+	margin-right: 0.25rem;
 }
 
 .dcm.dcm_handle.d2l-contextmenu-opener-open,


### PR DESCRIPTION
@dbatiste This fixes a couple things:

**1. Too much right-margin in legacy context/button menus**

From [button-menu](https://github.com/Brightspace/brightspace-integration/blob/master/sass/button-menu.scss#L25) in BSI, context-menu handles and button-menus in legacy are getting a right-margin of `0.75rem`, which in is causing this:

![screen shot 2017-05-30 at 5 54 36 pm](https://cloud.githubusercontent.com/assets/5491151/26606737/1e0ca366-4561-11e7-824d-203ba8ed9f9c.png)

Pre-Daylight things were nice and even:

![screen shot 2017-05-30 at 5 58 34 pm](https://cloud.githubusercontent.com/assets/5491151/26606845/a273f79e-4561-11e7-9e39-dab183f5cd14.png)

**2. No right-margin on MVC context-menu**

Noticed this while I was in there. MVC context-menus used to have even margins on either side, but in Daylight they only have a left-margin. 

![screen shot 2017-05-30 at 6 00 07 pm](https://cloud.githubusercontent.com/assets/5491151/26606912/dbc7fbd0-4561-11e7-9d29-3ab449039d88.png)

This balances that out again as well.

Man I'm looking forward to when we can just convert all this over to use the same web component.