### PR TITLE
keeping MVC grid cell vertical alignment consistent with pre-daylight

### DIFF
--- a/d2l-table.html
+++ b/d2l-table.html
@@ -4,5 +4,9 @@
 		.d2l-dialog-body d2l-table-wrapper {
 			--d2l-scroll-wrapper-action-offset: -10px;
 		}
+		.d2l-grid-mvc > * > tr > td,
+		.d2l-grid-mvc > * > tr > th {
+			vertical-align: top;
+		}
 	</style>
 </custom-style>


### PR DESCRIPTION
Pre-daylight, MVC grid cell alignment was "top" by default. The Daylight tables have a default "middle" vertical alignment, which caused a few places that were depending on top to manually start overriding it.

This puts the alignment back to "top" for MVC grids only. Legacy grids were always middle, so no need to impact them.

Corresponding change coming in the LMS to add the "d2l-grid-mvc" class and upgrade BSI.