### PR TITLE
New breakpoint design for navigation

### DIFF
--- a/sass/navigation/admin-menu.scss
+++ b/sass/navigation/admin-menu.scss
@@ -17,7 +17,7 @@
 	line-height: 1.5rem;
 }
 
-@media (max-width: 992px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-admin-menu {
 		display: none;
 	}

--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -3,13 +3,19 @@
 
 $d2l-navigation-header-height: 90px;
 $d2l-navigation-header-height-mobile: 72px;
-$d2l-navigation-header-height-mobile: 72px;
 $d2l-navigation-small-logo-height: 40px;
 $d2l-navigation-small-logo-width: 173px;
-$d2l-navigation-bp-mobile-menu: 992px;
-$d2l-navigation-bp-mobile-menu-medium: 615px;
-$d2l-navigation-bp-mobile-menu-small: 380px;
+$d2l-navigation-margin-regular: 30px;
+$d2l-navigation-margin-compact: 20px;
+
+$d2l-navigation-bp-username: 1055px;
+$d2l-navigation-bp-separators: 931px;
+$d2l-navigation-bp-mobile-menu: 767px;
+$d2l-navigation-bp-title-compact: 615px;
+$d2l-navigation-bp-title-hidden: 488px;
+$d2l-navigation-bp-mobile-menu-compact: 380px;
 $d2l-navigation-bp-title: 740px;
+
 
 .d2l-navigation-s-centerer {
 	margin: 0 auto;
@@ -52,7 +58,7 @@ a.d2l-navigation-s-link:focus {
 	width: calc(100% + 14px);
 }
 
-@media (max-width: 615px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-header-container {
 		height: $d2l-navigation-header-height-mobile;
 	}

--- a/sass/navigation/course-menu.scss
+++ b/sass/navigation/course-menu.scss
@@ -1,9 +1,14 @@
+@import 'common.scss';
+
 .d2l-navigation-s-course-menu {
 	height: 100%;
 }
 
 .d2l-navigation-s-course-menu .d2l-navigation-s-button-highlight {
 	margin: 0 5px;
+	@media (max-width: $d2l-navigation-bp-separators) {
+		margin: 0 $d2l-navigation-margin-compact / 2;
+	}
 }
 
 .d2l-navigation-s-course-menu d2l-dropdown {
@@ -14,7 +19,7 @@
 	line-height: 1.5rem;
 }
 
-@media (max-width: 554px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-course-menu,
 	.d2l-navigation-s-divider.d2l-navigation-s-course-menu-divider {
 		display: none;

--- a/sass/navigation/divider.scss
+++ b/sass/navigation/divider.scss
@@ -1,4 +1,5 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
+@import 'common.scss';
 
 .d2l-navigation-s-divider {
 	display: inline-block;
@@ -7,6 +8,9 @@
 	d2l-icon {
 		color: $d2l-color-mica;
 	}
+	@media (max-width: $d2l-navigation-bp-separators) {
+ 		display: none;
+ 	}
 }
 .d2l-navigation-s-divider-no-margin {
 	margin: 0;

--- a/sass/navigation/header-course.scss
+++ b/sass/navigation/header-course.scss
@@ -18,7 +18,7 @@
 	white-space: nowrap;
 }
 
-@media (max-width: 992px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-header-course {
 		display: none;
 	}

--- a/sass/navigation/header.scss
+++ b/sass/navigation/header.scss
@@ -1,4 +1,5 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
+@import 'common.scss';
 
 .d2l-navigation-s-header {
 	border-bottom: 1px solid $d2l-color-gypsum;
@@ -7,7 +8,10 @@
 .d2l-navigation-s-gutter {
 	display: inline-block;
 	flex: 1 1 auto;
-	min-width: 30px;
+	min-width: $d2l-navigation-margin-regular;
+	@media (max-width: $d2l-navigation-bp-title-compact) {
+		min-width: $d2l-navigation-margin-regular / 2;
+	}
 }
 
 .d2l-navigation-s-header-actions {
@@ -36,8 +40,20 @@
 	padding: 0 7px;
 
 	.d2l-navigation-s-header-container & {
-		@media (max-width: $d2l-navigation-bp-title) {
+		@media (max-width: $d2l-navigation-bp-title-hidden) {
 			display: none;
+		}
+		.d2l-navigation-s-logo {
+			@media (max-width: $d2l-navigation-bp-separators) {
+				margin-left: $d2l-navigation-margin-compact;
+				[dir="rtl"] & {
+					margin-left: 0;
+					margin-right: $d2l-navigation-margin-compact;
+				}
+			}
+		}
+		&.d2l-navigation-s-header-no-home-icon .d2l-navigation-s-logo {
+			margin: 0;
 		}
 		&.d2l-navigation-s-header-no-home-icon .d2l-navigation-s-logo-divider {
 			@media (min-width: $d2l-navigation-bp-mobile-menu) {
@@ -45,8 +61,8 @@
 			}
 		}
 		& .d2l-navigation-s-home-icon,
-		.d2l-navigation-s-has-title & .d2l-navigation-s-logo-divider,
-		.d2l-navigation-s-has-title & .d2l-navigation-s-logo {
+		.d2l-navigation-s-logo-divider,
+		.d2l-navigation-s-logo {
 			@media (max-width: $d2l-navigation-bp-mobile-menu) {
 				display: none;
 			}
@@ -71,4 +87,20 @@
 
 .d2l-navigation-s-has-branding .d2l-navigation-s-header-logo-area > .d2l-navigation-s-link {
 	font-size: 1.25rem;
+	@media (max-width: $d2l-navigation-bp-username) {
+ 		font-size: 1.1rem;
+ 	}
+	@media (max-width: $d2l-navigation-bp-separators) {
+ 		font-size: 1rem;
+ 	}
+	@media (max-width: $d2l-navigation-bp-title-compact) {
+ 		font-size: 0.9rem;
+ 	}
+	@media (max-width: $d2l-navigation-bp-separators) {
+		margin-left: $d2l-navigation-margin-compact;
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: $d2l-navigation-margin-compact;
+		}
+	}
 }

--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -80,7 +80,7 @@
 	margin-right: 0;
 }
 
-@media (max-width: 992px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-main {
 		display: none;
 	}

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -67,13 +67,10 @@
 	align-items: center;
 	border-bottom: 1px solid $d2l-color-gypsum;
 	display: flex;
-	height: $d2l-navigation-header-height;
+	height: $d2l-navigation-header-height-mobile;
 	padding: 0 1rem;
 	font-size: 1.1rem;
 	font-weight: 700;
-	@media (max-width: $d2l-navigation-bp-mobile-menu-medium) {
-		height: $d2l-navigation-header-height-mobile;
-	}
 }
 
 .d2l-navigation-s-mobile-menu-org-header {
@@ -165,7 +162,7 @@
 	font-size: 1rem;
 	font-weight: 700;
 	overflow: hidden;
-	padding: 0.75rem 1.5rem 1rem 1.5rem;
+	padding: 1rem;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
@@ -176,6 +173,10 @@
 
 .d2l-navigation-s-mobile-menu-header .d2l-navigation-s-header-logo-area {
 	flex-grow: 1;
+
+	.d2l-navigation-s-logo-divider {
+		display: inline-block;		
+	}
 
 	&.d2l-navigation-s-header-no-home-icon .d2l-navigation-s-logo-divider {
 		display: none;
@@ -203,7 +204,7 @@
 			display: none;
 		}
 	}
-	@media (max-width: $d2l-navigation-bp-mobile-menu-small) {
+	@media (max-width: $d2l-navigation-bp-mobile-menu-compact) {
 		.d2l-navigation-s-logo-divider {
 			d2l-icon {
 				display: none;

--- a/sass/navigation/notifications.scss
+++ b/sass/navigation/notifications.scss
@@ -1,3 +1,5 @@
+@import 'common.scss';
+
 .d2l-navigation-s-notifications {
 	display: inline-block;
 	flex: 0 0 auto;
@@ -7,13 +9,19 @@
 .d2l-navigation-s-notifications-wrapper {
 	display: inline-block;
 	height: 100%;
-	margin: 0 -15px;
+	margin: 0 (-$d2l-navigation-margin-regular) / 2;
+	@media (max-width: $d2l-navigation-bp-separators) {
+ 		margin: 0;
+ 	}
 }
 
 .d2l-navigation-s-notification {
 	display: inline-block;
 	height: 100%;
-	margin: 0 15px;
+	margin: 0 $d2l-navigation-margin-regular / 2;
+	@media (max-width: $d2l-navigation-bp-separators) {
+		margin: 0 $d2l-navigation-margin-compact / 2;
+	}
 	d2l-dropdown {
 		height: 100%;
 	}
@@ -43,8 +51,5 @@
 @media (max-width: 554px) {
 	.d2l-navigation-s-divider.d2l-navigation-s-notifications-divider {
 		display: none;
-	}
-	.d2l-navigation-s-notifications-div {
-		min-width: 30px;
 	}
 }

--- a/sass/navigation/personal-menu.scss
+++ b/sass/navigation/personal-menu.scss
@@ -1,5 +1,6 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 @import '../../bower_components/d2l-offscreen/offscreen.scss';
+@import 'common.scss';
 
 .d2l-navigation-s-personal-menu {
 	display: inline-block;
@@ -29,12 +30,15 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
+	@media (max-width: $d2l-navigation-bp-username) {
+		display: none;
+	}
 }
 [dir='rtl'] .d2l-navigation-s-personal-menu-text {
 	margin-left: 0;
 	margin-right: 10px;
 }
-@media (max-width: 992px) {
+@media (max-width: $d2l-navigation-bp-mobile-menu) {
 	.d2l-navigation-s-personal-menu-text {
 		@include d2l-offscreen();
 	}


### PR DESCRIPTION
Second go at this, now with less margin changes and other issues, I hope. :)

I still used margin-right and some RTL styles on a few elements because the combination of them and sharing of styles between the mobile menu and main nav is a bit tricky and I wanted to go with something I was more confident in.  But most margins are like what they were before.  I wish the mobile menu and nav styles were separated more and only used vars and mixins to share sometimes.

I tested in all the combinations of nav settings I am aware of (more or less!) and RTL and things seem.. okay so far.  I will check again tomorrow.

I also tried to break the branding flag less than I did before, but I am changing lots of stuff that effects both on/off for it.  So I assume lots is broken before.  Actually I just tried it and indeed it is in rough shape (logo doesn't show when it needs to, etc).  It would be way too difficult to try and address that fully.  I think that in retrospect we should have copy+pasted css and wrapped the old stuff in some "branding-off" class if possible.  Oh well.  Next time maybe.

