### PR TITLE
Dbatiste/image based nav link group fixes

### DIFF
--- a/sass/dialog.scss
+++ b/sass/dialog.scss
@@ -109,6 +109,7 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 }
 
 .d2l-dialog-inline {
+	max-height: 70vh;
 	max-width: 60vw;
 	width: auto;
 }
@@ -307,7 +308,12 @@ html.d2l-dialog-open, html.d2l-dialog-open body {
 	}
 
 	.d2l-dialog-inline {
+		max-height: 100% !important;
 		max-width: 100%;
+	}
+
+	.d2l-dialog-inline > .d2l-dialog-inner {
+		max-height: 100% !important;
 	}
 
 	.ddial_o2,

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -116,7 +116,8 @@ div.d2l-navigation-ib-item-group-icon {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-around;
-	max-width: 450px;
+	padding: 3px 2px;
+	max-width: 464px;
 }
 
 .d2l-navigation-ib-item-link-text {

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -175,6 +175,7 @@ div.d2l-navigation-ib-item-group-icon {
 .d2l-navigation-main-ib-pully[shown]:focus,
 .d2l-navigation-main-ib-pully[shown]:hover {
 	background-color: rgba(0,111,191,0.05);
+	outline: none;
 }
 
 .d2l-navigation-main-ib-pully-tab {


### PR DESCRIPTION
This PR makes some changes for image-based nav link groups:

* max-height for inline dialog and allow scrolling (overrides for mobile view included)
* minor style tweaks for link groups