### PR TITLE
port_fixes_for_DE26713_DE26712

### DIFF
--- a/table.html
+++ b/table.html
@@ -5,6 +5,11 @@
 			.d2l-dialog-body d2l-table-wrapper {
 				--d2l-scroll-wrapper-action-offset: -10px;
 			}
+			
+			.d2l-grid-mvc > * > tr > td,
+			.d2l-grid-mvc > * > tr > th {
+				vertical-align: top;
+			}
 
 		</style>
 	</template>


### PR DESCRIPTION
defaulting table cell alignment to "top" for MVC grids

Original PR: #579