### PR TITLE
DE25007 - Fix dialog close button rtl position.

### DIFF
--- a/sass/dialog.scss
+++ b/sass/dialog.scss
@@ -259,6 +259,11 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 	width: calc(1.3rem + 4px);
 	z-index: 1;
 
+	[dir='rtl'] & {
+		left: -0.3rem;
+		right: auto;
+	}
+
 	& > span {
 		width: 100%;
 		height: 100%;
@@ -268,12 +273,6 @@ $dialog-resize: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.
 			position: center center;
 			repeat: no-repeat;
 			size: 0.9rem 0.9rem;
-		}
-
-		[dir='rtl'] & {
-			left: -0.3rem;
-			right: auto;
-			background-position: 0 0;
 		}
 
 	}


### PR DESCRIPTION
The selector for positioning properties was incorrectly defined.  The background position for the icon was also not needed, since it is centered.