### PR TITLE
safety check around performance measuring

### DIFF
--- a/js/page-loading/web-components-ready.js
+++ b/js/page-loading/web-components-ready.js
@@ -8,8 +8,11 @@
 			return;
 		}
 		pageReady = true;
-		D2L.Performance.measure('d2l.page.visible', 'responseEnd');
-		D2L.Performance.measure('d2l.page.display', 'fetchStart');
+		// on slow CPUs, this can actually fire before the telemetry code has initialized
+		if (D2L && D2L.Performance) {
+			D2L.Performance.measure('d2l.page.visible', 'responseEnd');
+			D2L.Performance.measure('d2l.page.display', 'fetchStart');
+		}
 	}
 
 	// polyfill in use


### PR DESCRIPTION
I was finally able to reproduce that mysterious `Cannot read property ‘measure’ of undefined” JavaScript error locally on my machine. Previously we'd only seen it in test automation runs, and sporadically.

What causes it is a very slow CPU. I reproduced it in Chrome by throttling the CPU down to "20x slower" in Chrome dev tools. That seems to cause the web component import code (and this code in `web-components-ready.js`) to actually run _before_ the `D2L.Performance` library is initialized in `bsi.js`. This makes sense in Chrome, since it would treat an import with the same priority (or higher) than a JavaScript file, and `bsi.js` is loaded at the bottom of the page.

Beyond just protecting things here with a safety check, I'm not sure what a better solution might be for these types of "chicken and egg" issues. We could move the `web-components-ready.js` code into `bsi.js` below the definition of the library... but I'm pretty sure we've been down that road before.

@awikkerink @dbatiste @njostonehouse thoughts?