### PR TITLE
DE27540 - Update to latest d2l-scroll-spy to include ready event.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "d2l-offscreen": "^2.2.5",
     "d2l-performance": "^0.0.4",
     "d2l-polymer-behaviors": "^1.1.0",
-    "d2l-scroll-spy": "^0.0.1",
+    "d2l-scroll-spy": "^0.0.2",
     "d2l-table": "^0.6.8",
     "d2l-typography": "^5.4.0",
     "jquery-vui-accordion": "^0.3.2",


### PR DESCRIPTION
This new `d2l-scroll-spy` version is needed to properly support partial rendering of the scroll-spy import so that `registerPoint` is not called too early.