### PR TITLE
Update d2l-fetch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "d2l-colors": "^2.4.0",
     "d2l-dropdown": "^5.2.1",
     "d2l-fastdom-import": "Brightspace/fastdom-import#v1.0.2",
-    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.3",
     "d2l-fetch-auth": "Brightspace/d2l-fetch-auth#^0.7.0",
     "d2l-fetch-dedupe": "Brightspace/d2l-fetch-dedupe#^0.11.0",
     "d2l-fetch-simple-cache": "Brightspace/d2l-fetch-simple-cache#^0.5.0",


### PR DESCRIPTION
This fixes the issues seen with conflicts between d2l-fetch and require.js on UMD FRA pages in the LMS in not-Chrome browsers.