### PR TITLE
Add Array.prototype.includes polyfill for d2l-fetch-simple-cache

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "d2l-scroll-spy": "^0.0.2",
     "d2l-table": "^0.6.8",
     "d2l-typography": "^5.4.0",
+    "fetch": "whatwg-fetch#^2.0.3",
     "jquery-vui-accordion": "^0.3.2",
     "jquery-vui-collapsible-section": "^1.2.1",
     "jquery-vui-change-tracking": "^0.5.4",

--- a/bsi.html
+++ b/bsi.html
@@ -1,5 +1,8 @@
 <script src="js/page-loading/web-components-ready.js"></script>
 
+<!-- Required for d2l-fetch + IE11 -->
+<script src="bower_components/fetch/fetch.js"></script>
+
 <link rel="import" href="bower_components/d2l-fetch/d2l-fetch.html">
 <link rel="import" href="bower_components/d2l-fetch-auth/d2l-fetch-auth.html">
 <link rel="import" href="bower_components/d2l-fetch-dedupe/d2l-fetch-dedupe.html">

--- a/js/index.js
+++ b/js/index.js
@@ -12,6 +12,7 @@ require('../bower_components/jquery-vui-more-less/moreLess.js');
 require('../bower_components/jquery-vui-scrollspy/scroll-spy.js');
 require('../bower_components/d2l-telemetry/d2l-telemetry.js');
 require('./page-loading/timing-debug.js');
+require('./polyfill/Array.prototype.includes.js');
 
 window.BSI = window.BSI || {};
 window.BSI.Intl = require('d2l-intl');

--- a/js/polyfill/Array.prototype.includes.js
+++ b/js/polyfill/Array.prototype.includes.js
@@ -1,0 +1,54 @@
+// Required to use d2l-fetch-simple-cache
+
+'use strict';
+
+if (!Array.prototype.includes) {
+	Object.defineProperty(Array.prototype, 'includes', {
+		value: function(searchElement, fromIndex) {
+
+			// 1. Let O be ? ToObject(this value).
+			if (this == null) { // eslint-disable-line eqeqeq
+				throw new TypeError('"this" is null or not defined');
+			}
+
+			var o = Object(this);
+
+			// 2. Let len be ? ToLength(? Get(O, "length")).
+			var len = o.length >>> 0;
+
+			// 3. If len is 0, return false.
+			if (len === 0) {
+				return false;
+			}
+
+			// 4. Let n be ? ToInteger(fromIndex).
+			//    (If fromIndex is undefined, this step produces the value 0.)
+			var n = fromIndex | 0;
+
+			// 5. If n ≥ 0, then
+			//  a. Let k be n.
+			// 6. Else n < 0,
+			//  a. Let k be len + n.
+			//  b. If k < 0, let k be 0.
+			var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+			function sameValueZero(x, y) {
+				return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+			}
+
+			// 7. Repeat, while k < len
+			while (k < len) {
+				// a. Let elementK be the result of ? Get(O, ! ToString(k)).
+				// b. If SameValueZero(searchElement, elementK) is true, return true.
+				// c. Increase k by 1.
+				if (sameValueZero(o[k], searchElement)) {
+					return true;
+				}
+				k++;
+			}
+
+			// 8. Return false
+			return false;
+		}
+	});
+}


### PR DESCRIPTION
Not currently an issue due to how things are structured, but I forgot to move this polyfill over [from d2l-my-courses](https://github.com/Brightspace/d2l-my-courses-ui/blob/master/polyfill/Array.prototype.includes.js) when I restructured things. Required for IE11 because of course it is.

(I'll remove it from My Courses once this is merged)