### PR TITLE
Forcing on Polymer 1.11.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "jquery-vui-change-tracking": "^0.5.4",
     "jquery-vui-more-less": "^1.2.0",
     "jquery-vui-scrollspy": "~0.2.0",
-    "polymer": "^1.7.0",
+    "polymer": "1.11.0",
     "vui-breadcrumbs": "^2.1.0",
     "vui-dropdown": "^0.9.1",
     "vui-field": "^1.3.0",


### PR DESCRIPTION
1.11.1 breaks table's sticky buttons. Will investigate further and unlock this once we have a fix for table.