### PR TITLE
Use intl import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "d2l-loading-spinner": "^5.0.4",
     "d2l-menu": "^0.3.7",
     "d2l-more-less": "^2.2.2",
-    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#^2.8.0",
+    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#^2.9.0",
     "d2l-image-banner-overlay": "Brightspace/d2l-image-banner-overlay#^2.2.3",
     "d2l-offscreen": "^2.2.5",
     "d2l-polymer-behaviors": "^1.1.0",

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "d2l-fetch-simple-cache": "Brightspace/d2l-fetch-simple-cache#^0.6.0",
     "d2l-icons": "^3.6.1",
     "d2l-image-action": "^1.0.1",
+    "d2l-intl-import": "^1.0.0",
     "d2l-link": "^3.5.1",
     "d2l-loading-spinner": "^5.0.4",
     "d2l-menu": "^0.3.7",

--- a/bsi.html
+++ b/bsi.html
@@ -38,11 +38,12 @@
 <link rel="import" href="bower_components/d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="bower_components/d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="bower_components/d2l-dropdown/d2l-dropdown-more.html">
-<link rel="import" href="bower_components/d2l-menu/d2l-menu.html">
-<link rel="import" href="bower_components/d2l-menu/d2l-menu-item-link.html">
 <link rel="import" href="bower_components/d2l-image-action/d2l-image-action.html">
+<link rel="import" href="bower_components/d2l-intl-import/d2l-intl.html">
 <link rel="import" href="bower_components/d2l-icons/d2l-icons.html">
 <link rel="import" href="bower_components/d2l-loading-spinner/d2l-loading-spinner.html">
+<link rel="import" href="bower_components/d2l-menu/d2l-menu.html">
+<link rel="import" href="bower_components/d2l-menu/d2l-menu-item-link.html">
 <link rel="import" href="bower_components/d2l-polymer-behaviors/d2l-gestures-swipe.html">
 <link rel="import" href="bower_components/d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="bower_components/iron-icon/iron-icon.html">

--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,3 @@ require('../bower_components/jquery-vui-scrollspy/scroll-spy.js');
 require('../bower_components/d2l-telemetry/d2l-telemetry.js');
 require('./page-loading/timing-debug.js');
 require('./polyfill/Array.prototype.includes.js');
-
-window.BSI = window.BSI || {};
-window.BSI.Intl = require('d2l-intl');

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "chai": "^3.5.0",
     "clean-css": "^3.4.19",
     "cpy-cli": "^1.0.1",
-    "d2l-intl": "^0.3.2",
     "eslint": "^3.4.0",
     "eslint-config-brightspace": "0.2.1",
     "eslint-plugin-react": "^6.2.0",


### PR DESCRIPTION
Part 2 of this change.

Part 3 is in the monolith, where the few places that reference `BSI.Intl` need to switch to use the global `d2lIntl` object.