### PR TITLE
renaming BSI.Intl to d2lIntl

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -16,5 +16,4 @@ require('../bower_components/d2l-telemetry/d2l-telemetry.js');
 require('./page-loading/page-loading.js');
 require('./page-loading/timing-debug.js');
 
-window.BSI = window.BSI || {};
-window.BSI.Intl = require('d2l-intl');
+window.d2lIntl = require('d2l-intl');


### PR DESCRIPTION
Missed the fact that Daylight-OFF references the same `d2lIntl` object. So renaming to match corresponding change to master (Daylight) branch.