### PR TITLE
upgrading to hybrid version of d2l-table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "d2l-fetch-auth": "Brightspace/d2l-fetch-auth#^0.9.0",
     "d2l-fetch-dedupe": "Brightspace/d2l-fetch-dedupe#^0.13.0",
     "d2l-fetch-simple-cache": "Brightspace/d2l-fetch-simple-cache#^0.6.0",
-    "d2l-icons": "^3.6.1",
+    "d2l-icons": "^4.6.1",
     "d2l-image-action": "^1.0.1",
     "d2l-intl-import": "^1.0.0",
     "d2l-link": "^3.5.1",
@@ -20,11 +20,11 @@
     "d2l-more-less": "^2.2.2",
     "d2l-my-courses": "Brightspace/d2l-my-courses-ui#^3.3.6",
     "d2l-image-banner-overlay": "Brightspace/d2l-image-banner-overlay#^2.2.3",
-    "d2l-offscreen": "^2.2.5",
+    "d2l-offscreen": "^3.0.3",
     "d2l-polymer-behaviors": "^1.1.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.3",
     "d2l-scroll-spy": "^0.0.2",
-    "d2l-table": "^0.6.8",
+    "d2l-table": "^1.2.0",
     "d2l-typography": "^6.1.2",
     "fetch": "whatwg-fetch#^2.0.3",
     "jquery-vui-accordion": "^0.3.2",
@@ -32,7 +32,7 @@
     "jquery-vui-change-tracking": "^0.5.4",
     "jquery-vui-more-less": "^1.2.0",
     "jquery-vui-scrollspy": "~0.2.0",
-    "polymer": "1.11.0",
+    "polymer": "^1.11.2",
     "vui-breadcrumbs": "^2.1.0",
     "vui-dropdown": "^0.9.1",
     "vui-field": "^1.3.0",
@@ -43,13 +43,17 @@
     "vui-validation": "^1.1.0",
     "d2l-telemetry": "^0.0.9",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0"
+    "iron-iconset-svg": "^2.1.0"
   },
   "private": true,
   "resolutions": {
     "d2l-colors": "^3.1.2",
+    "d2l-icons": "^4.6.1",
+    "d2l-offscreen": "^3.0.3",
     "d2l-polymer-behaviors": "^1.1.0",
     "d2l-typography": "^6.1.2",
+    "iron-iconset-svg": "^2.1.0",
+    "iron-resizable-behavior": "^2.0.1",
     "webcomponentsjs": "^0.7"
   }
 }

--- a/d2l-table.html
+++ b/d2l-table.html
@@ -1,6 +1,6 @@
 <link rel="import" href="bower_components/d2l-table/d2l-table.html">
 <custom-style>
-	<style is="custom-style">
+	<style is="custom-style" include="d2l-table-style">
 		.d2l-dialog-body d2l-table-wrapper {
 			--d2l-scroll-wrapper-action-offset: -10px;
 		}


### PR DESCRIPTION
This will go with a corresponding pull request and change to the monolith that aligns its usage of `d2l-table` with the breaking changes introduced for the hybrid version.