### PR TITLE
adjusting the webComponentsReady measure to start at the time origin

### DIFF
--- a/js/page-loading/performance-timings.js
+++ b/js/page-loading/performance-timings.js
@@ -27,6 +27,7 @@
 	}
 
 	function wcReady() {
+		if (wcReadyFired) return;
 		wcReadyFired = true;
 		window.performance.mark('webComponentsReady');
 		tryMeasure();
@@ -46,7 +47,8 @@
 		measure('d2l.page.load', 'fetchStart', 'loadEventStart', false);
 		measure('d2l.page.server', 'requestStart', 'responseStart', false);
 		measure('d2l.page.download', 'responseStart', 'responseEnd', false);
-		measure('d2l.page.webComponentsReady', 'responseEnd', 'webComponentsReady', true);
+		measure('d2l.page.timeToClient', 'navigationStart', 'responseEnd', true);
+		measure('d2l.page.webComponentsReady', 'navigationStart', 'webComponentsReady', true);
 	}
 
 	if (document.readyState === 'complete') {


### PR DESCRIPTION
@svanherk @dbatiste Thoughts?

This switches the start time of the `webComponentsReady` measure to the beginning of the original navigation. Previously it used the `responseEnd`, or when it received the last byte of the response. This should bring the number in-line with the paint timings and TTI measures so that they're all comparable.

The downside to this approach is that network lookup, server processing and response download all have an impact on the WCR event. But they also impact the paint and TTI timings. To give us a bit more information, I've added the `d2l.page.timeToClient` measure, which tries to capture the time it took from `navigationStart` to `responseEnd`.