### PR TITLE
DE30092-always add top margin to each widget

### DIFF
--- a/sass/homepages/homepages.scss
+++ b/sass/homepages/homepages.scss
@@ -64,27 +64,11 @@ $viewport-width-sm: 768px;
 		margin: 0;
 	}
 
-	.homepage-col-4 {
-		margin-top: 30px;
-	}
-
-	.homepage-col-8 {
-		margin-top: 30px;
-	}
-
-	.homepage-col-12 {
-		margin-top: 30px;
-	}
-
 	.d2l-widget {
 		border-style: none;
 		margin-top: 30px;
 		margin-bottom: 0;
 		padding-bottom: 0;
-	}
-
-	.d2l-widget:first-child {
-		margin-top: 0;
 	}
 
 	.d2l-widget-header {


### PR DESCRIPTION
I think better fix is that always have top margin on each widget. I have tried again with displaying banner and Org title, both looked fine.

The problem with previous change is that when the panel is empty, it still has top-margin that is not needed any more.