### PR TITLE
polyfill findIndex for IE11

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
 import './polyfill/Array.prototype.includes.js';
+import './polyfill/Array.prototype.findIndex.js';
 import Lie from 'lie';
 if (typeof Promise === 'undefined') {
 	window.Promise = Lie;

--- a/js/polyfill/Array.prototype.findIndex.js
+++ b/js/polyfill/Array.prototype.findIndex.js
@@ -1,0 +1,50 @@
+// Required to use d2l-fetch-siren-entity-behavior
+
+'use strict';
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+// https://tc39.github.io/ecma262/#sec-array.prototype.findIndex
+if (!Array.prototype.findIndex) {
+	Object.defineProperty(Array.prototype, 'findIndex', {
+		value: function(predicate) {
+			// 1. Let O be ? ToObject(this value).
+			if (this === null) {
+				throw new TypeError('"this" is null or not defined');
+			}
+
+			var o = Object(this);
+
+			// 2. Let len be ? ToLength(? Get(O, "length")).
+			var len = o.length >>> 0;
+
+			// 3. If IsCallable(predicate) is false, throw a TypeError exception.
+			if (typeof predicate !== 'function') {
+				throw new TypeError('predicate must be a function');
+			}
+
+			// 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+			var thisArg = arguments[1];
+
+			// 5. Let k be 0.
+			var k = 0;
+
+			// 6. Repeat, while k < len
+			while (k < len) {
+				// a. Let Pk be ! ToString(k).
+				// b. Let kValue be ? Get(O, Pk).
+				// c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+				// d. If testResult is true, return k.
+				var kValue = o[k];
+				if (predicate.call(thisArg, kValue, k, o)) {
+					return k;
+				}
+				// e. Increase k by 1.
+				k++;
+			}
+
+			// 7. Return -1.
+			return -1;
+		},
+		configurable: true,
+		writable: true
+	});
+}


### PR DESCRIPTION
@omsmith @ChrisKraljevicD2L We'll most likely try and get this merged into master tonight and deployed to the LMS.

But wanted to give you a heads up in case it causes any issues or in case there is a better way to handle this. I just followed what had been done to polyfill `Array.includes`.

This is required for some recent changes to add domain whitelisting to `d2l-fetch-siren-entity-behavior`. That lib was updated in BSI yesterday and is required for d2l-rubric.