### PR TITLE
Fail when deployment fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ sudo: false
 script:
 - npm run test
 - npm run build
-after_success:
-- '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm run
-  publish:cdn'
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "x$TRAVIS_TAG" != "x" ]; then npm run publish:cdn; fi'
 env:
   global:
   # CDN_SECRET


### PR DESCRIPTION
According to the [Travis docs](https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build), a failure in `after_success` will not actually fail the build. This means that the deployment step failing would not actually fail the job, resulting in an erroneous success state.