### PR TITLE
Remove vui-breadcrumbs

### DIFF
--- a/bower-locker.bower.json
+++ b/bower-locker.bower.json
@@ -32,7 +32,6 @@
     "jquery-vui-collapsible-section": "^1.2.1",
     "jquery-vui-change-tracking": "^0.5.4",
     "polymer": "^1.11.3",
-    "vui-breadcrumbs": "^2.1.1",
     "vui-dropdown": "^0.9.1",
     "vui-field": "^1.3.0",
     "vui-focus": "^0.7.1",

--- a/bower.json
+++ b/bower.json
@@ -74,7 +74,6 @@
     "siren-parser-import": "https://github.com/Brightspace/siren-parser-import.git#71c9045600f0a399b45bff09fd1dda93160e04db",
     "stickyfill": "https://github.com/wilddeer/stickyfill.git#dfa336fb0723cae19e65eeb1986394ad565f7e6b",
     "susy": "https://github.com/ericam/susy.git#68b421259112eb882d2d1103738bee3b703e6bf3",
-    "vui-breadcrumbs": "https://github.com/Brightspace/valence-ui-breadcrumbs.git#1a0c1af6745a73b601597eb0d965df9c329bbc12",
     "vui-dropdown": "https://github.com/Brightspace/valence-ui-dropdown.git#5c50e4d8ae2d19b33514c477c20812f2264837f0",
     "vui-field": "https://github.com/Brightspace/valence-ui-field.git#613d3cc4fb370ac6ed020fecda4c64c089ed4610",
     "vui-focus": "https://github.com/Brightspace/valence-ui-focus.git#d092b7aa3c9eff70cbbbfc8567317f31fee4e563",
@@ -159,7 +158,6 @@
     "siren-parser-import": "71c9045600f0a399b45bff09fd1dda93160e04db",
     "stickyfill": "dfa336fb0723cae19e65eeb1986394ad565f7e6b",
     "susy": "68b421259112eb882d2d1103738bee3b703e6bf3",
-    "vui-breadcrumbs": "1a0c1af6745a73b601597eb0d965df9c329bbc12",
     "vui-dropdown": "5c50e4d8ae2d19b33514c477c20812f2264837f0",
     "vui-field": "613d3cc4fb370ac6ed020fecda4c64c089ed4610",
     "vui-focus": "d092b7aa3c9eff70cbbbfc8567317f31fee4e563",
@@ -170,7 +168,7 @@
     "webcomponentsjs": "8a2e40557b177e2cca0def2553f84c8269c8f93e"
   },
   "bowerLocker": {
-    "lastUpdated": "2018-07-17T17:54:24.203Z",
+    "lastUpdated": "2018-07-19T21:18:06.856Z",
     "lockedVersions": {
       "app-localize-behavior": "2.0.2",
       "d2l-alert": "3.1.0",
@@ -245,7 +243,6 @@
       "siren-parser-import": "7.0.0",
       "stickyfill": "2.0.5",
       "susy": "2.2.14",
-      "vui-breadcrumbs": "2.1.1",
       "vui-dropdown": "0.9.1",
       "vui-field": "1.3.0",
       "vui-focus": "0.7.1",

--- a/sass/deprecated/breadcrumbs.scss
+++ b/sass/deprecated/breadcrumbs.scss
@@ -1,0 +1,45 @@
+@import '../../bower_components/d2l-colors/d2l-colors.scss';
+@import '../../bower_components/d2l-link/d2l-link.scss';
+
+.vui-breadcrumbs {
+	color: $d2l-color-ferrite;
+	font-family: inherit;
+	font-size: 0.7rem;
+	font-weight: 400;
+	line-height: 1rem;
+	letter-spacing: 0.02rem;
+	margin: 0;
+	padding: 0;
+	list-style: none outside none;
+	& > li,
+	& > div,
+	& > span {
+		background-color: transparent;
+		border-width: 0;
+		display: inline-block;
+		list-style: none outside none;
+		&:last-child {
+			color: inherit;
+			&:after {
+				display: none;
+				[dir='rtl'] & {
+					display: none;
+				}
+			}
+		}
+		&:after {
+			content: url("data:image/svg+xml,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M11%209L7%203m4%206l-4%206%22%20stroke-linecap%3D%22round%22%20stroke%3D%22%23B9C2D0%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+			display: inline-block;
+			height: 1rem;
+			padding-left: .5rem;
+			padding-right: .5rem;
+			vertical-align: middle;
+			[dir='rtl'] & {
+				content: url("data:image/svg+xml,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M7%209l4-6M7%209l4%206%22%20stroke-linecap%3D%22round%22%20stroke%3D%22%23B9C2D0%22%20stroke-linejoin%3D%22round%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+			}
+		}
+		& > a {
+			@include d2l-link();
+		}
+	}
+}

--- a/sass/vui.scss
+++ b/sass/vui.scss
@@ -1,6 +1,6 @@
 @import '../bower_components/vui-focus/focus.css.scss';
 @import './deprecated/icons.scss';
-@import '../bower_components/vui-breadcrumbs/breadcrumbs.css.scss';
+@import './deprecated/breadcrumbs.scss';
 @import './deprecated/button.scss';
 @import '../bower_components/vui-dropdown/dropdown.css.scss';
 @import '../bower_components/jquery-vui-change-tracking/changeTracking.css.scss';


### PR DESCRIPTION
I'm going to pull all the ancient `vui-` stuff directly into BSI, starting here with breadcrumbs.

My reasoning is that most of these will become full-fledged Brightspace UI components at some point (maybe), but in the meantime the old `vui-` repos are still referencing colors and icons and such... and they're so old that they're starting to break. And most of them don't build anymore to even be able to go in and update them.