### PR TITLE
US97007 - Publish d2l-my-dashboard into BSI

### DIFF
--- a/bower-locker.bower.json
+++ b/bower-locker.bower.json
@@ -34,7 +34,8 @@
     "jquery-vui-collapsible-section": "^1.2.2",
     "jquery-vui-change-tracking": "^0.6.0",
     "polymer": "^1.11.3",
-    "susy": "^2.2.12"
+    "susy": "^2.2.12",
+    "d2l-my-dashboards": "^1.0.0"
   },
   "private": true,
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "d2l-menu": "https://github.com/BrightspaceUI/menu.git#c6258704b9ecb8d78e255ec2e1ecdba21f8c1654",
     "d2l-more-less": "https://github.com/BrightspaceUI/more-less.git#28b81ce5b8ae56b9590b1d8afca4c65d537f3ef2",
     "d2l-my-courses": "https://github.com/Brightspace/d2l-my-courses-ui.git#476d17bf7afca64ae901be095fdb7304549b620f",
+    "d2l-my-dashboards": "https://github.com/Brightspace/d2l-my-dashboards-ui.git#05f9d7f7aa9e13ef24525c255d7b935e0a48c9be",
     "d2l-navigation": "https://github.com/BrightspaceUI/navigation.git#cc75f8dfbbde833dda4c3a1f55a547ae41822dbc",
     "d2l-offscreen": "https://github.com/BrightspaceUI/offscreen.git#2c62edef92bb61ede35a93f2ff0660811b666d44",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#d1b764b90c349a20aa77c63978f960552882b1a5",
@@ -110,6 +111,7 @@
     "d2l-menu": "c6258704b9ecb8d78e255ec2e1ecdba21f8c1654",
     "d2l-more-less": "28b81ce5b8ae56b9590b1d8afca4c65d537f3ef2",
     "d2l-my-courses": "476d17bf7afca64ae901be095fdb7304549b620f",
+    "d2l-my-dashboards": "05f9d7f7aa9e13ef24525c255d7b935e0a48c9be",
     "d2l-navigation": "cc75f8dfbbde833dda4c3a1f55a547ae41822dbc",
     "d2l-offscreen": "2c62edef92bb61ede35a93f2ff0660811b666d44",
     "d2l-organization-hm-behavior": "d1b764b90c349a20aa77c63978f960552882b1a5",
@@ -162,7 +164,7 @@
     "webcomponentsjs": "8a2e40557b177e2cca0def2553f84c8269c8f93e"
   },
   "bowerLocker": {
-    "lastUpdated": "2018-08-03T14:08:36.926Z",
+    "lastUpdated": "2018-08-03T15:07:22.125Z",
     "lockedVersions": {
       "app-localize-behavior": "2.0.2",
       "d2l-alert": "3.1.0",
@@ -192,6 +194,7 @@
       "d2l-menu": "1.1.0",
       "d2l-more-less": "4.3.0",
       "d2l-my-courses": "5.6.1",
+      "d2l-my-dashboards": "1.0.0",
       "d2l-navigation": "0.2.0",
       "d2l-offscreen": "3.0.3",
       "d2l-organization-hm-behavior": "2.0.3",

--- a/polymer.json
+++ b/polymer.json
@@ -5,6 +5,7 @@
     "web-components/d2l-image-banner-overlay.html",
     "web-components/d2l-more-less.html",
     "web-components/d2l-my-courses.html",
+    "web-components/d2l-my-dashboards.html",
     "web-components/d2l-simple-overlay.html",
     "web-components/d2l-scroll-spy.html",
     "web-components/d2l-table.html",

--- a/web-components/d2l-my-dashboards.html
+++ b/web-components/d2l-my-dashboards.html
@@ -1,0 +1,1 @@
+<link rel="import" href="../bower_components/d2l-my-dashboards/d2l-my-dashboards.html">


### PR DESCRIPTION
After this I believe there are two things left to do.
1. Publish a release
2. Update the LMS to use the latest BSI


Seems like I only need to updated `daylight-polymer-1` since we do not use polymer-2 or polymer-3? is there a reason why there are not many updates to the `daylight-off-polymer-X` ones?