### PR TITLE
Rollback d2l-tile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "d2l-tabs": "https://github.com/BrightspaceUI/tabs.git#19d2816857e55bcc529382a98ac5f68d653e0fc3",
     "d2l-text-input": "https://github.com/BrightspaceUI/text-input.git#8a1296590d823dc97dfb6cefa4403f4d68482970",
     "d2l-textarea": "https://github.com/BrightspaceUI/textarea.git#02b253bec69b6c6e4d684387e7cf6a80661f4c5f",
-    "d2l-tile": "https://github.com/BrightspaceUI/tile.git#83643f39bc521a2800d4896b24b2c92b4f5f8685",
+    "d2l-tile": "https://github.com/BrightspaceUI/tile.git#b6ca541ddd2b2dc86f39834c6ae383bee9bb69f5",
     "d2l-tooltip": "https://github.com/BrightspaceUI/tooltip.git#4fe65f7156d5e75f9b480b59be1fa1ebe6b173e5",
     "d2l-typography": "https://github.com/BrightspaceUI/typography.git#10a37bee9871c1000bb4e85c83cc4288a2309d20",
     "fetch": "https://github.com/github/fetch.git#cbb313bf09512efda9444e40fe9e8ac432ac1108",
@@ -124,7 +124,7 @@
     "d2l-tabs": "19d2816857e55bcc529382a98ac5f68d653e0fc3",
     "d2l-text-input": "8a1296590d823dc97dfb6cefa4403f4d68482970",
     "d2l-textarea": "02b253bec69b6c6e4d684387e7cf6a80661f4c5f",
-    "d2l-tile": "83643f39bc521a2800d4896b24b2c92b4f5f8685",
+    "d2l-tile": "b6ca541ddd2b2dc86f39834c6ae383bee9bb69f5",
     "d2l-tooltip": "4fe65f7156d5e75f9b480b59be1fa1ebe6b173e5",
     "d2l-typography": "10a37bee9871c1000bb4e85c83cc4288a2309d20",
     "fetch": "cbb313bf09512efda9444e40fe9e8ac432ac1108",
@@ -162,7 +162,7 @@
     "webcomponentsjs": "8a2e40557b177e2cca0def2553f84c8269c8f93e"
   },
   "bowerLocker": {
-    "lastUpdated": "2018-08-02T18:43:57.383Z",
+    "lastUpdated": "2018-08-03T14:08:36.926Z",
     "lockedVersions": {
       "app-localize-behavior": "2.0.2",
       "d2l-alert": "3.1.0",
@@ -206,7 +206,7 @@
       "d2l-tabs": "0.3.0",
       "d2l-text-input": "0.4.0",
       "d2l-textarea": "0.6.1",
-      "d2l-tile": "3.1.2",
+      "d2l-tile": "3.1.1",
       "d2l-tooltip": "2.0.4",
       "d2l-typography": "6.1.3",
       "fetch": "2.0.4",


### PR DESCRIPTION
The 3.1.2 release of `d2l-tile` actually contained a breaking change to `d2l-card`. Until we sort that out, decrease (un-bump?) the `d2l-tile` version here.