### PR TITLE
fixes CSS not getting applied when shadow DOM is enabled

### DIFF
--- a/sass/navigation/header.scss
+++ b/sass/navigation/header.scss
@@ -28,7 +28,7 @@
 	overflow: hidden;
 	padding: 0 7px;
 
- 	.d2l-navigation-header-container & {
+	d2l-navigation-header & {
 		@media (max-width: $d2l-navigation-bp-title-hidden) {
 			display: none;
 		}


### PR DESCRIPTION
This fixes [this issue in d2l-navigation](https://github.com/BrightspaceUI/navigation/issues/6).

Now that navigation is using web components, when shadow DOM is enabled we can't reference their internal CSS classes like `.d2l-navigation-header-container` -- they're protected by scoping.

We'll have to be diligent of issues like this as we convert more of navigation over to WCs.