### PR TITLE
DE31284: table header content to vertical-align middle

### DIFF
--- a/web-components/d2l-table.html
+++ b/web-components/d2l-table.html
@@ -4,9 +4,11 @@
 		.d2l-dialog-body d2l-table-wrapper {
 			--d2l-scroll-wrapper-action-offset: -10px;
 		}
-		.d2l-grid-mvc > * > tr > td,
-		.d2l-grid-mvc > * > tr > th {
+		.d2l-grid-mvc > * > tr > td {
 			vertical-align: top;
+		}
+		.d2l-grid-mvc > * > tr > th {
+			vertical-align: middle;
 		}
 	</style>
 </custom-style>


### PR DESCRIPTION
https://rally1.rallydev.com/#/15545167705/detail/defect/252578974044

Subtle buttons now appear in some table headers (in menu flyout), making the `vertical-align: top` obvious and look off (as in the screenshot). Let me know if there are any tables where this could be an issue.

<img width="446" alt="screen shot 2018-09-26 at 11 53 42 am" src="https://user-images.githubusercontent.com/6804600/46099741-917d5c80-c195-11e8-998e-a918cef4cc11.png">
