### PR TITLE
DE31707 - Fix long course names in 10.8.7

### DIFF
--- a/sass/navigation/header.scss
+++ b/sass/navigation/header.scss
@@ -10,10 +10,16 @@
 	}
 }
 
+.d2l-navigation-header-left {
+	margin: -7px; // Needed for the overflow of the logo button highlight to expand past the left slot boundaries
+	overflow: hidden; // Needed for long course names
+}
+
 .d2l-navigation-s-header-open-button-wrapper {
 	display: inline-block;
 	flex: 0 1 auto;
 	height: 100%;
+	padding: 0 7px;
 	@media (min-width: ($d2l-navigation-bp-mobile-menu + 1)) {
 		display: none;
 	}
@@ -24,7 +30,6 @@
 	display: flex;
 	flex: 0 1 auto;
 	height: 100%;
-	margin: -7px;
 	overflow: hidden;
 	padding: 0 7px;
 

--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -2,10 +2,14 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-navigation-s-logo {
-	align-items: center;
-	display: inline-flex;
+	display: table;
 	height: 100%;
 	position: relative;
+}
+
+.d2l-navigation-s-logo-wrapper {
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .d2l-navigation-s-logo-wrapper > a {

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -166,6 +166,7 @@
 
 .d2l-navigation-s-mobile-menu-header .d2l-navigation-s-header-logo-area {
 	flex-grow: 1;
+	margin: -7px;
 
 	.d2l-navigation-s-logo-divider {
 		display: inline-block;		


### PR DESCRIPTION
The BSI changes needed to fix long course names in 10.8.7.

Related to this PR: https://github.com/BrightspaceUI/navigation/pull/14
Will also update `d2l-navigation` here once the above PR merges.