### PR TITLE
Adding styling for the new d2l-navigation-button so that the icon changes colour on hover and focus.

### DIFF
--- a/sass/navigation/personal-menu.scss
+++ b/sass/navigation/personal-menu.scss
@@ -69,6 +69,11 @@
 	width: 24px;
 }
 
+d2l-navigation-button button:focus .d2l-navigation-s-personal-menu-wrapper d2l-icon,
+d2l-navigation-button button:hover .d2l-navigation-s-personal-menu-wrapper d2l-icon {
+	color: inherit;
+}
+
 .d2l-navigation-s-personal-menu-text-wrapper {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
`d2l-icon` doesn't pick up the parent button's `color` changes on `:hover` or `:focus` by default. Changing the `color` in the personal menu to inherit when it's in a `d2l-navigation-button`.