### PR TITLE
Removing unneeded styling due to new buttons and links from d2l-navigation

### DIFF
--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -7,15 +7,6 @@
 	position: relative;
 }
 
-.d2l-navigation-s-logo-wrapper {
-	display: table-cell;
-	vertical-align: middle;
-}
-
-.d2l-navigation-s-logo-wrapper > a {
-	display: inline-block;
-}
-
 .d2l-navigation-s-logo img {
 	border: none; /* needed for IE10 */
 	max-height: 60px;
@@ -25,16 +16,6 @@
 .d2l-navigation-s-has-title .d2l-navigation-s-logo img {
 	max-height: $d2l-navigation-small-logo-height;
 	max-width: $d2l-navigation-small-logo-width;
-}
-
-.d2l-navigation-s-logo-link:hover, .d2l-navigation-s-logo-link:focus {
-	.d2l-navigation-s-highlight-bar {
-		display: block;
-	}
-}
-
-.d2l-navigation-s-logo-link:focus {
-	box-shadow: 0 0 3px 0 rgba( $d2l-color-celestine, 0.4 );
 }
 
 .d2l-navigation-s-no-login .d2l-navigation-s-logo {

--- a/sass/navigation/notifications.scss
+++ b/sass/navigation/notifications.scss
@@ -28,19 +28,6 @@
 	d2l-dropdown-content {
 		line-height: 1.5rem;
 	}
-	.d2l-navigation-s-notification-indicator {
-		display: none;
-		position: absolute;
-		right: -4px;
-		top: calc(50% - 19px);
-		d2l-icon {
-			height: 14px;
-			width: 14px;
-		}
-	}
-	&[data-has-notifications] .d2l-navigation-s-notification-indicator {
-		display: inline-block;
-	}
 }
 
 .d2l-navigation-s-notifications-div {

--- a/web-components/navigation-icons.html
+++ b/web-components/navigation-icons.html
@@ -1,14 +1,5 @@
 <link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
-<iron-iconset-svg name="navigation-t1" size="18">
-	<svg>
-		<defs>
-			<g id="notification-indicator">
-				<circle cx="9" cy="9" r="8" fill="#e57231" stroke="#ffffff" stroke-width="2" />
-			</g>
-		</defs>
-	</svg>
-</iron-iconset-svg>
 <iron-iconset-svg name="navigation-42" size="42">
 	<svg>
 		<defs>
@@ -19,4 +10,4 @@
 			</g>
 		</defs>
 	</svg>
-</svg>
+</iron-iconset-svg>


### PR DESCRIPTION
Removing styles removed in
- https://git.dev.d2l/projects/CORE/repos/platformtools/pull-requests/2736/overview
- https://git.dev.d2l/projects/CORE/repos/platformtools/pull-requests/2656/overview
- https://git.dev.d2l/projects/CORE/repos/platformtools/pull-requests/2653/overview

`d2l-navigation-s-button-highlight`
Still used in http://search.dev.d2l/source/xref/Lms/platformTools/navbars/D2L.PlatformTools.Navbars/Web/Desktop/Rendering/Views/Daylight/LinkHighlightIcon.Renderer.cs
`d2l-navigation-s-logo-wrapper`
Removed
`d2l-navigation-s-logo-link`
Removed
`d2l-navigation-s-highlight-bar`
Still used in http://search.dev.d2l/source/xref/Lms/platformTools/navbars/D2L.PlatformTools.Navbars/Web/Desktop/Rendering/Views/Daylight/LinkHighlightIcon.Renderer.cs
`d2l-navigation-s-notification-indicator`
Removed