### PR TITLE
increasing the space we leave for the nav admin menu

### DIFF
--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -42,11 +42,11 @@
 }
 
 .d2l-navigation-s-main-wrapper[has-edit-menu] {
-	margin-right: 45px;
+	margin-right: 52px;
 }
 
 [dir="rtl"] .d2l-navigation-s-main-wrapper[has-edit-menu] {
-	margin-left: 45px;
+	margin-left: 52px;
 	margin-right: 0;
 }
 


### PR DESCRIPTION
This was bothering me for a while. :)

I think this happened when our "..." [menus increased in size](https://github.com/BrightspaceUI/dropdown/pull/133/files) from `34px` to match the size of all our other menus at `42px`. The space that we leave in the navbar for this menu didn't increase accordingly.

Looks like we were leaving ~`11px` previously (45-36) -- I've adjusted it to be `10px`.