### PR TITLE
Queue for callbacks interested in being called after WCR

### DIFF
--- a/js/d2l-web-components-ready.js
+++ b/js/d2l-web-components-ready.js
@@ -1,0 +1,35 @@
+var ready;
+
+function dcl() {
+	window.removeEventListener('DOMContentLoaded', dcl);
+	ready();
+}
+
+function wcr() {
+	window.removeEventListener('WebComponentsReady', wcr);
+	ready();
+}
+
+module.exports = {
+	WebComponentsReady: new Promise(function(resolve) {
+		ready = resolve;
+	}),
+	init: function() {
+		if (window.WebComponents && !window.WebComponents.ready) {
+			window.addEventListener('WebComponentsReady', wcr);
+		} else {
+			if (document.readyState === 'interactive' || document.readyState === 'complete') {
+				ready();
+			} else {
+				window.addEventListener('DOMContentLoaded', dcl);
+			}
+		}
+	},
+	reset: function() {
+		window.removeEventListener('WebComponentsReady', wcr);
+		window.removeEventListener('DOMContentLoaded', dcl);
+		this.WebComponentsReady = new Promise(function(resolve) {
+			ready = resolve;
+		}.bind(this));
+	}
+};

--- a/js/d2l-web-components-ready.js
+++ b/js/d2l-web-components-ready.js
@@ -30,6 +30,6 @@ module.exports = {
 		window.removeEventListener('DOMContentLoaded', dcl);
 		this.WebComponentsReady = new Promise(function(resolve) {
 			ready = resolve;
-		}.bind(this));
+		});
 	}
 };

--- a/js/index.js
+++ b/js/index.js
@@ -1,9 +1,4 @@
-import './polyfill/Array.prototype.includes.js';
-import './polyfill/Array.prototype.findIndex.js';
-import Lie from 'lie';
-if (typeof Promise === 'undefined') {
-	window.Promise = Lie;
-}
+import './polyfills.js';
 
 window.D2L = window.D2L || {};
 

--- a/js/index.js
+++ b/js/index.js
@@ -7,6 +7,10 @@ if (typeof Promise === 'undefined') {
 
 window.D2L = window.D2L || {};
 
+import webComponentsReady from './d2l-web-components-ready.js';
+webComponentsReady.init();
+window.D2L.WebComponentsReady = webComponentsReady.WebComponentsReady;
+
 import FastDom from './d2l-fastdom.js';
 window.D2L.FastDom = FastDom;
 

--- a/js/polyfills.js
+++ b/js/polyfills.js
@@ -1,0 +1,6 @@
+import './polyfill/Array.prototype.includes.js';
+import './polyfill/Array.prototype.findIndex.js';
+import Lie from 'lie';
+if (typeof Promise === 'undefined') {
+	window.Promise = Lie;
+}

--- a/test/web-components-ready.js
+++ b/test/web-components-ready.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const expect = require('chai').expect,
+	sinon = require('sinon'),
+	wcr = require('../js/d2l-web-components-ready.js');
+
+require('chai')
+	.use(require('sinon-chai'))
+	.should();
+
+describe('d2l-web-components-ready', () => {
+
+	beforeEach(() => {
+		global.document = {
+			readyState: 'complete'
+		};
+		global.window = {
+			addEventListener: sinon.spy(),
+			removeEventListener: sinon.spy()
+		};
+	});
+
+	afterEach(() => {
+		wcr.reset();
+	});
+
+	function dispatchEventListener() {
+		var cb = global.window.addEventListener.getCall(0).args[1];
+		cb();
+	}
+
+	[undefined, null, 0, 'asdf', [1, 2, 3]].forEach((cb) => {
+		it(`should not explode on non-function (${cb}) callback`, (done) => {
+			wcr.WebComponentsReady.then(cb);
+			wcr.WebComponentsReady.then(done);
+			wcr.init();
+		});
+	});
+
+	it('should execute callbacks in order', (done) => {
+		let count = 0;
+		wcr.WebComponentsReady.then(() => {
+			count++;
+			expect(count).to.equal(1);
+		});
+		wcr.init();
+		wcr.WebComponentsReady.then(() => {
+			count++;
+			expect(count).to.equal(2);
+		});
+		wcr.WebComponentsReady.then(() => {
+			count++;
+			expect(count).to.equal(3);
+			done();
+		});
+	});
+
+	describe('Polyfill not present', () => {
+
+		describe('loading readyState', () => {
+
+			beforeEach(() => {
+				global.document.readyState = 'dunno';
+			});
+
+			it('should add listener for "DOMContentLoaded" when in other readyState', () => {
+				wcr.init();
+				global.window.addEventListener
+					.should.have.been.calledWith('DOMContentLoaded');
+			});
+
+			it('should remove "DOMContentLoaded" listener', () => {
+				wcr.init();
+				dispatchEventListener();
+				global.window.removeEventListener
+					.should.have.been.calledWith('DOMContentLoaded');
+			});
+
+			it('should execute callbacks when "DOMContentLoaded" fires', (done) => {
+				wcr.WebComponentsReady.then(done);
+				wcr.init();
+				dispatchEventListener();
+			});
+
+			it('should execute callbacks in order', (done) => {
+				let count = 0;
+				wcr.WebComponentsReady.then(() => {
+					count++;
+					expect(count).to.equal(1);
+				});
+				wcr.init();
+				wcr.WebComponentsReady.then(() => {
+					count++;
+					expect(count).to.equal(2);
+					done();
+				});
+				dispatchEventListener();
+			});
+
+		});
+
+		describe('finished readyState', () => {
+
+			['interactive', 'complete'].forEach((readyState) => {
+				it(`should execute callback immediately when in "${readyState}" readyState`, (done) => {
+					let count = 0;
+					global.document.readyState = readyState;
+					wcr.WebComponentsReady.then(() => {
+						count++;
+						expect(count).to.equal(1);
+					});
+					wcr.init();
+					wcr.WebComponentsReady.then(() => {
+						count++;
+						expect(count).to.equal(2);
+						done();
+					});
+				});
+			});
+
+		});
+
+	});
+
+	describe('Polyfill present', () => {
+
+		beforeEach(() => {
+			global.window.WebComponents = {};
+		});
+
+		it('should not call callback initially', (done) => {
+			wcr.WebComponentsReady.then(() => {
+				done(new Error('should not be called'));
+			});
+			wcr.init();
+			done();
+		});
+
+		it('should add listener for "WebComponentsReady"', () => {
+			wcr.init();
+			global.window.addEventListener
+				.should.have.been.calledWith('WebComponentsReady');
+		});
+
+		it('should remove "WebComponentsReady" listener', () => {
+			wcr.init();
+			dispatchEventListener();
+			global.window.removeEventListener
+				.should.have.been.calledWith('WebComponentsReady');
+		});
+
+		it('should execute callbacks when "WebComponentsReady" fires', (done) => {
+			wcr.WebComponentsReady.then(done);
+			wcr.init();
+			dispatchEventListener();
+		});
+
+		it('should execute callback immediately if "WebComponentsReady" already fired', (done) => {
+			global.window.WebComponents.ready = true;
+			global.document.readyState = 'interactive';
+			wcr.WebComponentsReady.then(done);
+			wcr.init();
+		});
+
+	});
+
+});

--- a/test/web-components-ready.js
+++ b/test/web-components-ready.js
@@ -37,21 +37,23 @@ describe('d2l-web-components-ready', () => {
 		});
 	});
 
-	it('should execute callbacks in order', (done) => {
+	it('should execute all callbacks', (done) => {
 		let count = 0;
+		function check() {
+			if (count === 3) done();
+		}
 		wcr.WebComponentsReady.then(() => {
 			count++;
-			expect(count).to.equal(1);
+			check();
 		});
 		wcr.init();
 		wcr.WebComponentsReady.then(() => {
 			count++;
-			expect(count).to.equal(2);
+			check();
 		});
 		wcr.WebComponentsReady.then(() => {
 			count++;
-			expect(count).to.equal(3);
-			done();
+			check();
 		});
 	});
 
@@ -84,15 +86,17 @@ describe('d2l-web-components-ready', () => {
 
 			it('should execute callbacks in order', (done) => {
 				let count = 0;
+				function check() {
+					if (count === 2) done();
+				}
 				wcr.WebComponentsReady.then(() => {
 					count++;
-					expect(count).to.equal(1);
+					check();
 				});
 				wcr.init();
 				wcr.WebComponentsReady.then(() => {
 					count++;
-					expect(count).to.equal(2);
-					done();
+					check();
 				});
 				dispatchEventListener();
 			});


### PR DESCRIPTION
I don't intend to merge this until after branching on Friday.

Currently we have a bunch of code waiting for the `WebComponentsReady` event, mostly to defer but sometimes to ensure that all the polyfills are there before using them. These places have ugly bits because `WebComponentsReady` may have already fired, so they need to check `d2lWCRDispatched` and conditionally add a listener or execute right away. That sucks.

Additionally, in Polymer 3 our web component bundles are going to load asynchronously. So just because `WebComponentsReady` has fired doesn't mean that our bundles have loaded, only that the polyfills are there. So we need a nice mechanism that knows when both have occurred in Polymer 3 land.

Enter: this pull request.

It's loosely modelled after [`WebComponents.waitFor`](https://github.com/webcomponents/webcomponentsjs/blob/92063e0956ad0d5ed1f527026029cc2f94977340/webcomponents-loader.js#L95):
```
D2L.OnWebComponentsReady(function() {
    // I'm confident WebComponentsReady has fired!
});
```
Essentially it keeps an in-order queue of callbacks and calls them all as soon as `WebComponentsReady` fires. If more things get added to the queue after that, they'll execute immediately.

When I bring this into Polymer 3, I'll add an additional check to make sure our core bundle has loaded.
