### PR TITLE
DE32168 - Cert Fix - 10.8.9 - Fix logo centering in Firefox

### DIFF
--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -2,7 +2,6 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-navigation-s-logo {
-	display: table;
 	height: 100%;
 	position: relative;
 }


### PR DESCRIPTION
Remove `display: table`, as the logo no longer has `display: table-cell`.