### PR TITLE
DE32352 - Fix logo centering in Firefox

### DIFF
--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -2,7 +2,6 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-navigation-s-logo {
-	display: table;
 	height: 100%;
 	position: relative;
 }


### PR DESCRIPTION
Applying the fix from https://github.com/Brightspace/brightspace-integration/pull/1139 to `master` (10.8.10) as well.