### PR TITLE
adjusting the WebComponentsReady promise to always wait for the event

### DIFF
--- a/js/d2l-web-components-ready.js
+++ b/js/d2l-web-components-ready.js
@@ -8,41 +8,19 @@ function check() {
 	}
 }
 
-function dcl() {
-	window.removeEventListener('DOMContentLoaded', dcl);
-	webComponentsReady = true;
-	check();
-}
-
-function wcr() {
-	window.removeEventListener('WebComponentsReady', wcr);
-	webComponentsReady = true;
-	check();
-}
-
 module.exports = {
 	WebComponentsLoaded: function() {
 		d2lComponentsLoaded = true;
 		check();
 	},
+	WCRDispatched: function() {
+		webComponentsReady = true;
+		check();
+	},
 	WebComponentsReady: new Promise(function(resolve) {
 		ready = resolve;
 	}),
-	init: function() {
-		if (window.WebComponents && !window.WebComponents.ready) {
-			window.addEventListener('WebComponentsReady', wcr);
-		} else {
-			if (document.readyState === 'interactive' || document.readyState === 'complete') {
-				webComponentsReady = true;
-				check();
-			} else {
-				window.addEventListener('DOMContentLoaded', dcl);
-			}
-		}
-	},
 	reset: function() {
-		window.removeEventListener('WebComponentsReady', wcr);
-		window.removeEventListener('DOMContentLoaded', dcl);
 		d2lComponentsLoaded = false;
 		webComponentsReady = false;
 		this.WebComponentsReady = new Promise(function(resolve) {

--- a/js/index.js
+++ b/js/index.js
@@ -3,11 +3,14 @@ import './polyfills.js';
 window.D2L = window.D2L || {};
 
 import webComponentsReady from './d2l-web-components-ready.js';
-webComponentsReady.init();
 window.D2L.WebComponentsLoaded = webComponentsReady.WebComponentsLoaded;
+window.D2L.WCRDispatched = webComponentsReady.WCRDispatched;
 window.D2L.WebComponentsReady = webComponentsReady.WebComponentsReady;
-if (window.D2L._webComponentsLoaded) {
+if (window.d2lWCLoaded) {
 	webComponentsReady.WebComponentsLoaded();
+}
+if (window.d2lWCRDispatched) {
+	webComponentsReady.WCRDispatched();
 }
 
 import FastDom from './d2l-fastdom.js';

--- a/test/web-components-ready.js
+++ b/test/web-components-ready.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect,
-	sinon = require('sinon'),
-	wcr = require('../js/d2l-web-components-ready.js');
+const wcr = require('../js/d2l-web-components-ready.js');
 
 require('chai')
 	.use(require('sinon-chai'))
@@ -10,31 +8,16 @@ require('chai')
 
 describe('d2l-web-components-ready', () => {
 
-	beforeEach(() => {
-		global.document = {
-			readyState: 'complete'
-		};
-		global.window = {
-			addEventListener: sinon.spy(),
-			removeEventListener: sinon.spy()
-		};
-	});
-
 	afterEach(() => {
 		wcr.reset();
 	});
-
-	function dispatchEventListener() {
-		var cb = global.window.addEventListener.getCall(0).args[1];
-		cb();
-	}
 
 	[undefined, null, 0, 'asdf', [1, 2, 3]].forEach((cb) => {
 		it(`should not explode on non-function (${cb}) callback`, (done) => {
 			wcr.WebComponentsReady.then(cb);
 			wcr.WebComponentsReady.then(done);
-			wcr.init();
 			wcr.WebComponentsLoaded();
+			wcr.WCRDispatched();
 		});
 	});
 
@@ -50,13 +33,13 @@ describe('d2l-web-components-ready', () => {
 		wcr.WebComponentsReady.then(() => {
 			done(new Error('should not be called'));
 		});
-		wcr.init();
+		wcr.WCRDispatched();
 		done();
 	});
 
 	it('should execute after WebComponentsReady and WebComponentsLoaded', (done) => {
 		wcr.WebComponentsReady.then(done);
-		wcr.init();
+		wcr.WCRDispatched();
 		wcr.WebComponentsLoaded();
 	});
 
@@ -69,7 +52,7 @@ describe('d2l-web-components-ready', () => {
 			count++;
 			check();
 		});
-		wcr.init();
+		wcr.WCRDispatched();
 		wcr.WebComponentsReady.then(() => {
 			count++;
 			check();
@@ -79,123 +62,6 @@ describe('d2l-web-components-ready', () => {
 			count++;
 			check();
 		});
-	});
-
-	describe('Polyfill not present', () => {
-
-		describe('loading readyState', () => {
-
-			beforeEach(() => {
-				global.document.readyState = 'dunno';
-			});
-
-			it('should add listener for "DOMContentLoaded" when in other readyState', () => {
-				wcr.init();
-				global.window.addEventListener
-					.should.have.been.calledWith('DOMContentLoaded');
-			});
-
-			it('should remove "DOMContentLoaded" listener', () => {
-				wcr.init();
-				dispatchEventListener();
-				global.window.removeEventListener
-					.should.have.been.calledWith('DOMContentLoaded');
-			});
-
-			it('should execute callbacks when "DOMContentLoaded" fires', (done) => {
-				wcr.WebComponentsReady.then(done);
-				wcr.init();
-				wcr.WebComponentsLoaded();
-				dispatchEventListener();
-			});
-
-			it('should execute callbacks in order', (done) => {
-				let count = 0;
-				function check() {
-					if (count === 2) done();
-				}
-				wcr.WebComponentsReady.then(() => {
-					count++;
-					check();
-				});
-				wcr.init();
-				wcr.WebComponentsLoaded();
-				wcr.WebComponentsReady.then(() => {
-					count++;
-					check();
-				});
-				dispatchEventListener();
-			});
-
-		});
-
-		describe('finished readyState', () => {
-
-			['interactive', 'complete'].forEach((readyState) => {
-				it(`should execute callback immediately when in "${readyState}" readyState`, (done) => {
-					let count = 0;
-					global.document.readyState = readyState;
-					wcr.WebComponentsReady.then(() => {
-						count++;
-						expect(count).to.equal(1);
-					});
-					wcr.init();
-					wcr.WebComponentsLoaded();
-					wcr.WebComponentsReady.then(() => {
-						count++;
-						expect(count).to.equal(2);
-						done();
-					});
-				});
-			});
-
-		});
-
-	});
-
-	describe('Polyfill present', () => {
-
-		beforeEach(() => {
-			global.window.WebComponents = {};
-		});
-
-		it('should not call callback initially', (done) => {
-			wcr.WebComponentsReady.then(() => {
-				done(new Error('should not be called'));
-			});
-			wcr.init();
-			wcr.WebComponentsLoaded();
-			done();
-		});
-
-		it('should add listener for "WebComponentsReady"', () => {
-			wcr.init();
-			global.window.addEventListener
-				.should.have.been.calledWith('WebComponentsReady');
-		});
-
-		it('should remove "WebComponentsReady" listener', () => {
-			wcr.init();
-			dispatchEventListener();
-			global.window.removeEventListener
-				.should.have.been.calledWith('WebComponentsReady');
-		});
-
-		it('should execute callbacks when "WebComponentsReady" fires', (done) => {
-			wcr.WebComponentsReady.then(done);
-			wcr.init();
-			wcr.WebComponentsLoaded();
-			dispatchEventListener();
-		});
-
-		it('should execute callback immediately if "WebComponentsReady" already fired', (done) => {
-			global.window.WebComponents.ready = true;
-			global.document.readyState = 'interactive';
-			wcr.WebComponentsReady.then(done);
-			wcr.init();
-			wcr.WebComponentsLoaded();
-		});
-
 	});
 
 });

--- a/web-components/bsi.html
+++ b/web-components/bsi.html
@@ -61,8 +61,7 @@
 <link rel="import" href="../bower_components/d2l-users/all-imports.html">
 <link rel="import" href="navigation-icons.html">
 <script>
-	window.D2L = window.D2L || {};
-	window.D2L._webComponentsLoaded = true;
+	window.d2lWCLoaded = true;
 	if (window.D2L.WebComponentsLoaded !== undefined) {
 		window.D2L.WebComponentsLoaded();
 	}


### PR DESCRIPTION
This fixes `DE32339`, which was a bug with the navbar's chomper where it initially thought it had more room than it ended up with, causing the "more" menu to contain too few links.

There'll be a corresponding code change to the monolith to have it set `d2lWCRDispatched` and call `D2L.WCRDispatched()`. This change will be replicated in the `polymer-2` and `polymer-3` branches.

What was happening: in non-Chrome, about 10% of the time when this code ran, `WebComponents.ready` was `true`, causing it to add an event listener for `DOMContentLoaded` instead of `WebComponentsReady`. This means the polyfill had loaded, but for whatever reason the event hadn't been fully dispatched yet and web components hadn't upgraded.

For the navbar, this meant that its CSS hadn't yet been applied when the chomper went to calculate the available width. This resulted in it thinking it had hundreds of pixels of extra space that once the CSS was applied and the navbar was centred it didn't have.

The change I'm making here and in the monolith returns things to the way they were originally. The `WebComponentPolyfillEarlyJavaScriptBlock` will add an event listener for `WebComponentsReady` and when it fires it will set `d2lWCRDispatched` and also call `D2L.WCRDispatched()` if it's present on the page. That will trigger the `D2L.WebComponentsReady` promise if `WebComponentsLoaded` has also been called.