### PR TITLE
Update package-lock to get latest version of activities branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,7 +1609,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#d7f13e5bd2672a88a3f6ff20a293ca0bda874082",
+      "version": "github:BrightspaceHypermediaComponents/activities#3af0716c8f3c9fc09de82e807e695e214903806a",
       "from": "github:BrightspaceHypermediaComponents/activities#add_evaluation-hub_skeleton_with_table",
       "dev": true,
       "requires": {
@@ -1624,26 +1624,10 @@
         "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
         "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#588ebfd4d00642358f9395b719dac42399e0bf8d",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#cdf546047dea5415739df1f38bab139f8c1497b8",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#bed996403a40dbb92675224df4fa2dc25e58ba5f",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#40e8e95e61e88a8f984af4c0dbb89d75464d0fd8",
         "d2l-table": "github:BrightspaceUI/table#01e309d635cb25974f67d923539e4b2cb6665b93",
         "d2l-typography": "github:BrightspaceUI/typography#62489aaf9e93d66a54e5838ad97f616951030c2f",
         "fastdom": "^1.0.8"
-      },
-      "dependencies": {
-        "d2l-table": {
-          "version": "github:BrightspaceUI/table#01e309d635cb25974f67d923539e4b2cb6665b93",
-          "from": "github:BrightspaceUI/table#semver:^2.0.0",
-          "dev": true,
-          "requires": {
-            "@polymer/iron-resizable-behavior": "^3.0.0-pre.18",
-            "@polymer/polymer": "^3.0.0",
-            "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-            "d2l-icons": "github:BrightspaceUI/icons#7df2e338974029bb4e1005799d2dd88b6e83145c",
-            "fastdom": "^1.0.8",
-            "resize-observer-polyfill": "^1.5.0",
-            "stickyfilljs": "^2.1.0"
-          }
-        }
       }
     },
     "d2l-alert": {
@@ -1880,7 +1864,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#963b67f11e4b8110162857c9a95f930c446a2954",
+      "version": "github:BrightspaceUI/navigation#58c2f4baf3f7b8adde55cd5a0bb1967f67bc932a",
       "from": "github:BrightspaceUI/navigation#polymer-3-2019-01-04-170733",
       "dev": true,
       "requires": {
@@ -1949,23 +1933,13 @@
       }
     },
     "d2l-polymer-siren-behaviors": {
-      "version": "github:Brightspace/polymer-siren-behaviors#bed996403a40dbb92675224df4fa2dc25e58ba5f",
-      "from": "github:Brightspace/polymer-siren-behaviors#semver:^1.0.0",
+      "version": "github:Brightspace/polymer-siren-behaviors#40e8e95e61e88a8f984af4c0dbb89d75464d0fd8",
+      "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "dev": true,
       "requires": {
         "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
         "fastdom": "^1.0.8",
         "siren-parser": "^8.0.0"
-      },
-      "dependencies": {
-        "d2l-fetch": {
-          "version": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-          "from": "github:Brightspace/d2l-fetch#semver:^2.0.0",
-          "dev": true,
-          "requires": {
-            "frau-jwt": "^2.0.0"
-          }
-        }
       }
     },
     "d2l-save-status": {
@@ -3168,9 +3142,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.99.tgz",
-      "integrity": "sha512-2+EyjU/3Iu+UEwcZimGLQ3VVloCjoLYcjm88vXW89UsqAwsXjgjNrnsK5iaxj6/H8CECSsaiMKlLIASjGhNuBg==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.100.tgz",
+      "integrity": "sha512-cEUzis2g/RatrVf8x26L8lK5VEls1AGnLHk6msluBUg/NTB4wcXzExTsGscFq+Vs4WBBU2zbLLySvD4C0C3hwg==",
       "dev": true
     },
     "end-of-stream": {
@@ -19241,14 +19215,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-      "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
+      "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
-        "supports-color": "^5.5.0"
+        "supports-color": "^6.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -19256,6 +19230,15 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },


### PR DESCRIPTION
Checked on my local instance, I'm no longer seeing the "already registered" error