### PR TITLE
Fix navbar non-links

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -36,13 +36,15 @@ a.d2l-navigation-s-link:visited {
 
 .d2l-branding-navigation-dark-foreground-color a.d2l-navigation-s-link,
 .d2l-branding-navigation-dark-foreground-color a.d2l-navigation-s-link:link,
-.d2l-branding-navigation-dark-foreground-color a.d2l-navigation-s-link:visited {
+.d2l-branding-navigation-dark-foreground-color a.d2l-navigation-s-link:visited,
+.d2l-branding-navigation-dark-foreground-color div.d2l-navigation-s-item > span {
 	color: $d2l-branding-navigation-dark-foreground-color;
 }
 
 .d2l-branding-navigation-light-foreground-color a.d2l-navigation-s-link,
 .d2l-branding-navigation-light-foreground-color a.d2l-navigation-s-link:link,
-.d2l-branding-navigation-light-foreground-color a.d2l-navigation-s-link:visited {
+.d2l-branding-navigation-light-foreground-color a.d2l-navigation-s-link:visited,
+.d2l-branding-navigation-light-foreground-color div.d2l-navigation-s-item > span {
 	color: $d2l-branding-navigation-light-foreground-color;
 }
 

--- a/sass/navigation/course-menu.scss
+++ b/sass/navigation/course-menu.scss
@@ -1,5 +1,3 @@
-@import 'common.scss';
-
 .d2l-navigation-s-course-menu {
 	height: 100%;
 }

--- a/sass/navigation/divider.scss
+++ b/sass/navigation/divider.scss
@@ -1,5 +1,3 @@
-@import 'common.scss';
-
 .d2l-navigation-s d2l-navigation-separator {
 	flex: 0 0 auto;
 

--- a/sass/navigation/header.scss
+++ b/sass/navigation/header.scss
@@ -1,5 +1,4 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
-@import 'common.scss';
 
 .d2l-navigation-s-gutter { // This is also in d2l-navigation; can be removed if the mobile menu is moved to d2l-navigation
 	display: inline-block;

--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -1,4 +1,3 @@
-@import 'common.scss';
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 
 .d2l-navigation-s-logo {

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -1,5 +1,4 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
-@import 'common.scss';
 
 .d2l-navigation-s-mobile-menu[data-state="closed"] {
 	display: none;

--- a/sass/navigation/notifications.scss
+++ b/sass/navigation/notifications.scss
@@ -1,5 +1,3 @@
-@import 'common.scss';
-
 .d2l-navigation-s-notifications {
 	display: inline-block;
 	flex: 0 0 auto;

--- a/sass/navigation/personal-menu.scss
+++ b/sass/navigation/personal-menu.scss
@@ -1,6 +1,5 @@
 @import '../../bower_components/d2l-colors/d2l-colors.scss';
 @import '../../bower_components/d2l-offscreen/offscreen.scss';
-@import 'common.scss';
 
 .d2l-navigation-s-personal-menu {
 	display: inline-block;


### PR DESCRIPTION
Two fixes here:
1. Applying the branding colours to non-links like the course name, which end up just being inside a `<span>` and not an `<a>`
2. While verifying the fix I noticed that all the CSS in `navigation/common.scss` was getting included **8 TIMES**, since it was imported into 8 different SCSS files. It only needs to be imported once, haha. This saves ~44KB in download size, yikes!