### PR TITLE
[fix] Rubrics editor BSI integration is causing tinymce to be loaded …

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -12,8 +12,7 @@
     "web-components/d2l-scroll-spy.html",
     "web-components/d2l-table.html",
     "web-components/d2l-rubric.html",
-    "web-components/d2l-rubric-editor.html",
-    "web-components/d2l-rubric-structure-editor.html"
+    "web-components/d2l-rubric-editor.html"
   ],
   "sources": [],
   "extraDependencies": [

--- a/web-components/d2l-rubric-structure-editor.html
+++ b/web-components/d2l-rubric-structure-editor.html
@@ -1,1 +1,0 @@
-<link rel="import" href="../bower_components/d2l-rubric/editor/d2l-rubric-structure-editor.html">


### PR DESCRIPTION
…twice on pages using legacy LMS HTML editor