### PR TITLE
applying styles to button.d2l-button to override Edge shady CSS styles

### DIFF
--- a/sass/button.scss
+++ b/sass/button.scss
@@ -1,11 +1,19 @@
 @import '../node_modules/d2l-button/d2l-button.scss';
 @import 'common.scss';
 
-.d2l-button {
+/**
+ * DE32805: we need to apply button styles to button.d2l-button as in Edge,
+ * the shady CSS polyfill reuses the "d2l-button" CSS class, causing
+ * a collision.
+ * GitHub issue tracking this: https://github.com/webcomponents/shadycss/issues/238
+ */
+.d2l-button,
+button.d2l-button {
 	@include d2l-button();
 	margin-right: $d2l-button-spacing;
 }
-[dir='rtl'] .d2l-button {
+[dir='rtl'] .d2l-button,
+[dir='rtl'] button.d2l-button {
 	margin-left: $d2l-button-spacing;
 	margin-right: 0;
 }


### PR DESCRIPTION
The issue here is that the shady CSS polyfill is using the `d2l-button` CSS class for `<d2l-button>`'s styles. In IE11 and previously in Polymer 1, it postfixes that class name like `d2l-button-0`. This causes a collision with these styles and because `button.d2l-button` is more specific, these styles lose out. 

The biggest issue here is that `<d2l-button>` sets `width: 100%` on the inner button element (but keeps `width:auto` on `<d2l-button>` itself), and when that gets applied here to our `<button>` elements they go 100% width. This caused DE32805.

I've [created this GitHub issue](https://github.com/webcomponents/shadycss/issues/238) with the Shady CSS polyfill, so we'll hopefully see a fix there and we can remove this hack.