### PR TITLE
only re-applying width to override Edge

### DIFF
--- a/sass/button.scss
+++ b/sass/button.scss
@@ -2,18 +2,20 @@
 @import 'common.scss';
 
 /**
- * DE32805: we need to apply button styles to button.d2l-button as in Edge,
+ * DE32805: we need to re-apply this to button.d2l-button as in Edge,
  * the shady CSS polyfill reuses the "d2l-button" CSS class, causing
- * a collision.
+ * a collision and forcing buttons to "width: 100%".
  * GitHub issue tracking this: https://github.com/webcomponents/shadycss/issues/238
  */
-.d2l-button,
 button.d2l-button {
+	width: auto;
+}
+
+.d2l-button {
 	@include d2l-button();
 	margin-right: $d2l-button-spacing;
 }
-[dir='rtl'] .d2l-button,
-[dir='rtl'] button.d2l-button {
+[dir='rtl'] .d2l-button {
 	margin-left: $d2l-button-spacing;
 	margin-right: 0;
 }


### PR DESCRIPTION
This reverts most of #1193 and keeps only the part that re-applies `width: auto` on buttons. In Edge, because the polyfill reuses our `d2l-button` CSS class for the `<d2l-button>` web component's `button` element, it gets `width: 100%` on all buttons.

There will be a corresponding change in LP that will ensure button styles are inlined and do not use generated classes anymore. Otherwise this `width: auto` would always be more specific than those generated styles.