### PR TITLE
Refresh polymer-3 from master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,12 +70,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
-      "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+      "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.0",
+        "@babel/types": "^7.3.2",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.10",
         "source-map": "^0.5.0",
@@ -297,9 +297,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+      "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -324,9 +324,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.1.tgz",
-      "integrity": "sha512-Nmmv1+3LqxJu/V5jU9vJmxR/KIRWFk2qLHmbB56yRRRFhlaSuOVXscX3gUmhaKgUhzA3otOHVubbIEVYsZ0eZg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
+      "integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -455,9 +455,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
-      "integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
+      "integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -780,9 +780,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
-      "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+      "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1176,6 +1176,17 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "append-buffer": {
@@ -1872,9 +1883,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000934",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000934.tgz",
-      "integrity": "sha512-o7yfZn0R9N+mWAuksDsdLsb1gu9o//XK0QSU0zSSReKNRsXsFc/n/psxi0YSPNiqlKxImp5h4DHnAPdwYJ8nNA==",
+      "version": "1.0.30000935",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
+      "integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1947,24 +1958,23 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
+      "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.0"
       }
     },
     "circular-json": {
@@ -2358,9 +2368,9 @@
         "@polymer/iron-flex-layout": "^3.0.0-pre.18",
         "@polymer/iron-selector": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
       }
     },
     "d2l-activities": {
@@ -2370,20 +2380,20 @@
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-course-image": "github:Brightspace/course-image#a90779d33c4c0e7cbc0c0bca957adb0f9c5b3b26",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-course-image": "github:Brightspace/course-image#semver:^3",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6.5.0",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#a2f1dffaf05ee9c4ba791774e072fcaef11b3d8f",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-table": "github:BrightspaceUI/table#954ac95880cdf519e8ab77e4a2f166943e618d48",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^1",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-table": "github:BrightspaceUI/table#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "del": "^3.0.0",
         "fastdom": "^1.0.8",
         "merge-stream": "^1.0.1",
@@ -2391,24 +2401,24 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#a48e416d06861d98ab6bb1350add2bfb54464988",
+      "version": "github:Brightspace/d2l-activity-alignments#dc0fb3fe84acd7f674d7dab7359091543d0092a6",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^1",
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-alert": "github:BrightspaceUI/alert#c26fc5799971f9a3cfea0baae60fcab279c62d04",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#0f47c25e34918cc734a6882c8b884b996ffd41b6",
+        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#semver:^6",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-inputs": "github:BrightspaceUI/inputs#727c7efae857a796551aa4ee16ab95660795bd95",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#dce9e572dea085743d28f2b169835f5066407c01",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
-        "s-html": "github:Brightspace/s-html#c26a7e0a7ec352e7bc1ae7cf009c3e8f627fac67"
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^2",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "s-html": "github:Brightspace/s-html#semver:^2.0.0"
       }
     },
     "d2l-alert": {
@@ -2417,11 +2427,11 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-button": {
@@ -2431,10 +2441,10 @@
       "requires": {
         "@polymer/iron-media-query": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-button-group": {
@@ -2443,12 +2453,12 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
         "fastdom": "^1.0.8"
       }
     },
@@ -2458,11 +2468,11 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "fastdom": "^1.0.8",
         "resize-observer-polyfill": "^1.5.0"
       }
@@ -2489,7 +2499,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#3961feab735b5076172d522183459deeca1c1cb5",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
         "intersection-observer": "^0.5.1",
         "siren-parser": "^8.0.0"
       }
@@ -2500,7 +2510,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "sortablejs": "github:SortableJS/Sortable#8794188794eff5685ded3e5755fe8e9212ab994f"
+        "sortablejs": "github:SortableJS/Sortable#8794188794"
       }
     },
     "d2l-dropdown": {
@@ -2510,11 +2520,11 @@
       "requires": {
         "@polymer/iron-iconset-svg": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9"
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
       }
     },
     "d2l-enrollments": {
@@ -2524,21 +2534,21 @@
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-card": "github:BrightspaceUI/card#48fd1ff741106010a7f63e7f00dcacb9ba18f9d4",
-        "d2l-course-image": "github:Brightspace/course-image#a90779d33c4c0e7cbc0c0bca957adb0f9c5b3b26",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-card": "github:BrightspaceUI/card#semver:^6",
+        "d2l-course-image": "github:Brightspace/course-image#semver:^3",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#3961feab735b5076172d522183459deeca1c1cb5",
-        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#a2f1dffaf05ee9c4ba791774e072fcaef11b3d8f",
-        "d2l-status-indicator": "github:BrightspaceUI/status-indicator#7e55dbc434a5dff830297ac30aa7598e25cf0da9",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#aa1915f15fac4a3e2650463ea563d06357d45067",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
+        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^1",
+        "d2l-status-indicator": "github:BrightspaceUI/status-indicator#semver:^3",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "intersection-observer": "^0.5.1",
         "siren-parser": "^8.0.0"
       }
@@ -2582,7 +2592,7 @@
       "requires": {
         "@polymer/iron-meta": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "siren-parser": "^8.0.0"
       }
     },
@@ -2592,7 +2602,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "fastdom": "^1.0.8"
       }
     },
@@ -2602,10 +2612,10 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-fetch-auth": "^1.2.0",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90"
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6"
       }
     },
     "d2l-hypermedia-constants": {
@@ -2621,7 +2631,7 @@
       "requires": {
         "@polymer/iron-iconset-svg": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-image-banner-overlay": {
@@ -2631,20 +2641,20 @@
       "requires": {
         "@polymer/iron-scroll-threshold": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-alert": "github:BrightspaceUI/alert#c26fc5799971f9a3cfea0baae60fcab279c62d04",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-image-selector": "github:Brightspace/image-selector#3fb0386213632489b91ccbab326d3e519b5afd48",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#3961feab735b5076172d522183459deeca1c1cb5",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-simple-overlay": "github:Brightspace/simple-overlay#53fe64eb74545e466e6be1f7c24a1c99e572e678",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-image-selector": "github:Brightspace/image-selector#semver:^4",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-simple-overlay": "github:Brightspace/simple-overlay#semver:^3",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "siren-parser": "^8.0.0"
       }
     },
@@ -2654,14 +2664,14 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-course-image": "github:Brightspace/course-image#a90779d33c4c0e7cbc0c0bca957adb0f9c5b3b26",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#3961feab735b5076172d522183459deeca1c1cb5",
-        "d2l-search-widget": "github:Brightspace/d2l-search-widget-ui#ffd62351f69634072976ddc4a1836bc45e229a9f",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-course-image": "github:Brightspace/course-image#semver:^3",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
+        "d2l-search-widget": "github:Brightspace/d2l-search-widget-ui#semver:^4",
         "siren-parser": "^8.0.0"
       }
     },
@@ -2671,12 +2681,12 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8"
       }
     },
@@ -2692,8 +2702,8 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
       }
     },
     "d2l-loading-spinner": {
@@ -2702,7 +2712,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-localize-behavior": {
@@ -2721,11 +2731,11 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-hierarchical-view": "github:BrightspaceUI/hierarchical-view#792b7c64a7744b3092d82123f132c189ba212e00",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-hierarchical-view": "github:BrightspaceUI/hierarchical-view#semver:^2",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
       }
     },
     "d2l-more-less": {
@@ -2734,10 +2744,10 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "fastdom": "^1.0.8",
         "resize-observer-polyfill": "^1.5.0"
       }
@@ -2754,26 +2764,26 @@
         "@polymer/iron-pages": "^3.0.0",
         "@polymer/iron-scroll-threshold": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-alert": "github:BrightspaceUI/alert#c26fc5799971f9a3cfea0baae60fcab279c62d04",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-course-image": "github:Brightspace/course-image#a90779d33c4c0e7cbc0c0bca957adb0f9c5b3b26",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-enrollments": "github:BrightspaceHypermediaComponents/enrollments#41d6678afec24727e2926eb2a9057bef14691118",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-course-image": "github:Brightspace/course-image#semver:^3",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-enrollments": "github:BrightspaceHypermediaComponents/enrollments#semver:^1",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-image-selector": "github:Brightspace/image-selector#3fb0386213632489b91ccbab326d3e519b5afd48",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#3961feab735b5076172d522183459deeca1c1cb5",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-search-widget": "github:Brightspace/d2l-search-widget-ui#ffd62351f69634072976ddc4a1836bc45e229a9f",
-        "d2l-simple-overlay": "github:Brightspace/simple-overlay#53fe64eb74545e466e6be1f7c24a1c99e572e678",
-        "d2l-tabs": "github:BrightspaceUI/tabs#5cd08559945e8f14668dff00d90b12d022835f0f",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-image-selector": "github:Brightspace/image-selector#semver:^4",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-search-widget": "github:Brightspace/d2l-search-widget-ui#semver:^4",
+        "d2l-simple-overlay": "github:Brightspace/simple-overlay#semver:^3",
+        "d2l-tabs": "github:BrightspaceUI/tabs#semver:^1",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "intersection-observer": "^0.5.1",
         "siren-parser": "^8.0.0"
       }
@@ -2784,36 +2794,36 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-alert": "github:BrightspaceUI/alert#c26fc5799971f9a3cfea0baae60fcab279c62d04",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-card": "github:BrightspaceUI/card#48fd1ff741106010a7f63e7f00dcacb9ba18f9d4",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#0f47c25e34918cc734a6882c8b884b996ffd41b6",
-        "d2l-inputs": "github:BrightspaceUI/inputs#727c7efae857a796551aa4ee16ab95660795bd95",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-simple-overlay": "github:Brightspace/simple-overlay#53fe64eb74545e466e6be1f7c24a1c99e572e678",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#aa1915f15fac4a3e2650463ea563d06357d45067",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-card": "github:BrightspaceUI/card#semver:^6",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#semver:^6",
+        "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-simple-overlay": "github:Brightspace/simple-overlay#semver:^3",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "siren-parser": "^8.0.0"
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#8a3e23809b758179e325929f4b6604df52834615",
+      "version": "github:BrightspaceUI/navigation#c6e8c001a61d22f48ebf7706384e95da7c393e51",
       "from": "github:BrightspaceUI/navigation#semver:^3",
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8",
         "resize-observer-polyfill": "^1.5.0"
       }
@@ -2832,12 +2842,12 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-inputs": "github:BrightspaceUI/inputs#727c7efae857a796551aa4ee16ab95660795bd95",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-organization-hm-behavior": {
@@ -2846,17 +2856,17 @@
       "dev": true
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#a2f1dffaf05ee9c4ba791774e072fcaef11b3d8f",
+      "version": "github:BrightspaceHypermediaComponents/organizations#f0f5fba908f3870c90f242fe85867424548e85a3",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^1",
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#aa1915f15fac4a3e2650463ea563d06357d45067",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "siren-parser": "^8.0.0"
       }
     },
@@ -2867,11 +2877,11 @@
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "d2l-hypermedia-constants": "^6",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#aa1915f15fac4a3e2650463ea563d06357d45067",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8"
       }
     },
@@ -2889,7 +2899,7 @@
       "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "dev": true,
       "requires": {
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "fastdom": "^1.0.8",
         "siren-parser": "^8.0.0"
       }
@@ -2900,7 +2910,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-rubric": {
@@ -2912,31 +2922,31 @@
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-accordion": "github:BrightspaceUI/accordion#d4fa752b99076e825b1a3a6f3073d8dd70a9183a",
-        "d2l-alert": "github:BrightspaceUI/alert#c26fc5799971f9a3cfea0baae60fcab279c62d04",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-dnd-sortable": "github:Brightspace/dnd-sortable#322dee0b8b6e97df5d7ab1ac5bff21a2c97fb5c1",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#dc9b44c97c2cf2e5b974403c5cd2bd5abef15b1a",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#0f47c25e34918cc734a6882c8b884b996ffd41b6",
-        "d2l-html-editor": "github:Brightspace/d2l-html-editor#978fc12b4391d1d87ff412de125ebc0724ce8097",
+        "d2l-accordion": "github:BrightspaceUI/accordion#semver:^1",
+        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-dnd-sortable": "github:Brightspace/dnd-sortable#semver:^3",
+        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#semver:^6",
+        "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-inputs": "github:BrightspaceUI/inputs#727c7efae857a796551aa4ee16ab95660795bd95",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-menu": "github:BrightspaceUI/menu#d2e6e9a62ac6dbd777c9dfeddc8f2b6c8c557796",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-save-status": "github:Brightspace/d2l-save-status#e48a9e90d7cef005957a0295b696cf0692b86e78",
-        "d2l-table": "github:BrightspaceUI/table#954ac95880cdf519e8ab77e4a2f166943e618d48",
-        "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#8db1cec35d6cf40eb6c345158c2bfbfdc8ea417e",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#aa1915f15fac4a3e2650463ea563d06357d45067",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-save-status": "github:Brightspace/d2l-save-status#semver:^3",
+        "d2l-table": "github:BrightspaceUI/table#semver:^2",
+        "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8",
-        "s-html": "github:Brightspace/s-html#c26a7e0a7ec352e7bc1ae7cf009c3e8f627fac67"
+        "s-html": "github:Brightspace/s-html#semver:^2.0.0"
       }
     },
     "d2l-save-status": {
@@ -2945,10 +2955,10 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-scroll-spy": {
@@ -2967,10 +2977,10 @@
       "requires": {
         "@polymer/iron-input": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "siren-parser": "^8.0.0"
       }
     },
@@ -2980,15 +2990,15 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-accordion": "github:BrightspaceUI/accordion#d4fa752b99076e825b1a3a6f3073d8dd70a9183a",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-progress": "github:BrightspaceUI/progress#ccd0e1f21b349e3819e1a2708826566e58bf670c",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
-        "siren-entity": "github:BrightspaceHypermediaComponents/siren-entity#eee66e35414e401829a79f4ccf70ffbe21ee19a5"
+        "d2l-accordion": "github:BrightspaceUI/accordion#semver:^1",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-progress": "github:BrightspaceUI/progress#semver:^1",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "siren-entity": "github:BrightspaceHypermediaComponents/siren-entity#semver:^1"
       }
     },
     "d2l-sequence-viewer": {
@@ -2998,15 +3008,15 @@
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-navigation": "github:BrightspaceUI/navigation#8a3e23809b758179e325929f4b6604df52834615",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-sequence-navigator": "github:BrightspaceHypermediaComponents/d2l-sequence-navigator#a10b68b5bb020895cb8cebc9198459ea67f2ba17",
-        "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#16032d4fe2a7d60942bb175072f28406c947ac2d",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
-        "polymer-frau-jwt": "github:Brightspace/polymer-frau-jwt#7f664ad2a8df42890231ef7d8ddc7c5cd3e9c248"
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-navigation": "github:BrightspaceUI/navigation#semver:^3",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-sequence-navigator": "github:BrightspaceHypermediaComponents/d2l-sequence-navigator#semver:^2",
+        "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "polymer-frau-jwt": "github:Brightspace/polymer-frau-jwt#semver:^1"
       }
     },
     "d2l-sequences": {
@@ -3015,14 +3025,14 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-content-icons": "github:Brightspace/d2l-content-icons#7cccfda77ea56544be038276decad8d4d307bdc0",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#a04fa684b437eacb9897a0afdbae91ad4f95f96b",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-navigation": "github:BrightspaceUI/navigation#8a3e23809b758179e325929f4b6604df52834615",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "s-html": "github:Brightspace/s-html#c26a7e0a7ec352e7bc1ae7cf009c3e8f627fac67"
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-content-icons": "github:Brightspace/d2l-content-icons#semver:^3",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-navigation": "github:BrightspaceUI/navigation#semver:^3",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "s-html": "github:Brightspace/s-html#semver:^2.0.0"
       }
     },
     "d2l-simple-overlay": {
@@ -3032,10 +3042,10 @@
       "requires": {
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-status-indicator": {
@@ -3044,7 +3054,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-table": {
@@ -3054,8 +3064,8 @@
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "fastdom": "^1.0.8",
         "resize-observer-polyfill": "^1.5.0",
         "stickyfilljs": "^2.1.0"
@@ -3067,11 +3077,11 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8"
       }
     },
@@ -3087,9 +3097,9 @@
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-typography": {
@@ -3098,7 +3108,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-users": {
@@ -3107,12 +3117,12 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
-        "d2l-typography": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7"
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "dashdash": {
@@ -3341,6 +3351,15 @@
             "object.omit": "^2.0.0",
             "parse-glob": "^3.0.4",
             "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "ordered-read-streams": {
@@ -4104,6 +4123,15 @@
             "object.omit": "^2.0.0",
             "parse-glob": "^3.0.4",
             "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "ordered-read-streams": {
@@ -5163,7 +5191,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5184,12 +5213,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5204,17 +5235,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5331,7 +5365,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5343,6 +5378,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5357,6 +5393,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5364,12 +5401,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5388,6 +5427,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5468,7 +5508,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5480,6 +5521,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5565,7 +5607,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5601,6 +5644,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5620,6 +5664,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5663,12 +5708,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7012,7 +7059,7 @@
       "dev": true,
       "requires": {
         "bower": "^1.7.7",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "js-base64": {
@@ -7227,9 +7274,9 @@
       }
     },
     "lit-html": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.0.0-rc.2.tgz",
-      "integrity": "sha512-4bq34lhVmwWly1zBXicOBJLOwaWfjOVbchEEmFnZLuztxjh5wRd2WqV0URX8Q47MQ7PaIjn/eXyTRKsYhSAeRw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.0.0.tgz",
+      "integrity": "sha512-oeWlpLmBW3gFl7979Wol2LKITpmKTUFNn7PnFbh6YNynF61W74l6x5WhwItAwPRSATpexaX1egNnRzlN4GOtfQ==",
       "dev": true
     },
     "load-json-file": {
@@ -7333,12 +7380,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.escape": {
@@ -8057,13 +8098,10 @@
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -13268,7 +13306,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13292,13 +13331,15 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13315,19 +13356,22 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13458,7 +13502,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13472,6 +13517,7 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13488,6 +13534,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13496,13 +13543,15 @@
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -13523,6 +13572,7 @@
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13611,7 +13661,8 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13625,6 +13676,7 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13720,7 +13772,8 @@
               "version": "5.1.1",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
               "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13762,6 +13815,7 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13783,6 +13837,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13831,13 +13886,15 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -21355,6 +21412,15 @@
             "parse-glob": "^3.0.4",
             "regex-cache": "^0.4.2"
           }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
         }
       }
     },
@@ -21694,7 +21760,7 @@
       "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796"
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
       }
     },
     "siren-parser": {
@@ -23073,6 +23139,17 @@
         "now-and-later": "^2.0.0",
         "remove-bom-buffer": "^3.0.0",
         "vinyl": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "ware": {

--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -2,8 +2,6 @@
 @import '../common.scss';
 
 $d2l-navigation-header-height-mobile: 72px;
-$d2l-navigation-small-logo-height: 40px;
-$d2l-navigation-small-logo-width: 173px;
 $d2l-navigation-margin-regular: 30px;
 $d2l-navigation-margin-compact: 20px;
 

--- a/sass/navigation/logo.scss
+++ b/sass/navigation/logo.scss
@@ -1,19 +1,6 @@
-@import '../../node_modules/d2l-colors/d2l-colors.scss';
-
 .d2l-navigation-s-logo {
 	height: 100%;
 	position: relative;
-}
-
-.d2l-navigation-s-logo img {
-	border: none; /* needed for IE10 */
-	max-height: 60px;
-	max-width: 260px;
-}
-
-.d2l-navigation-s-has-title .d2l-navigation-s-logo img {
-	max-height: $d2l-navigation-small-logo-height;
-	max-width: $d2l-navigation-small-logo-width;
 }
 
 .d2l-navigation-s-no-login .d2l-navigation-s-logo {

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -179,13 +179,6 @@
 		font-size: 1rem;
 	}
 
-	.d2l-navigation-s-logo {
-		img {
-			max-height: $d2l-navigation-small-logo-height;
-			max-width: $d2l-navigation-small-logo-width;
-		}
-	}
-
 	@media (max-width: $d2l-navigation-bp-mobile-menu) {
 		.d2l-navigation-s-title-divider {
 			d2l-icon {


### PR DESCRIPTION
This pulls in the fix to the navbar logo from `master` to `polymer-3`.

@dbatiste FYI this is reverting your `package-lock` changes, similar to what @awikkerink had. I'm using NPM `6.7.0` so this must be a change in newer versions... you may want to update. I also wonder if this will solve some of the issues we've been having!