### PR TITLE
removing "d2l-navigation-s-no-branding"

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -58,8 +58,6 @@ a.d2l-navigation-s-link:visited {
 	outline: none;
 }
 
-.d2l-navigation-s-no-branding a.d2l-navigation-s-link:hover,
-.d2l-navigation-s-no-branding a.d2l-navigation-s-link:focus,
 .d2l-navigation-s-header-logo-area a.d2l-navigation-s-link:hover,
 .d2l-navigation-s-header-logo-area a.d2l-navigation-s-link:focus,
 .d2l-navigation-s-linkarea-no-color a.d2l-navigation-s-link:hover,

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -15,10 +15,6 @@
 	border-bottom-style: none;
 }
 
-.d2l-navigation-s-no-branding .d2l-navigation-main-ib {
-	border-top: 1px solid $d2l-color-gypsum;
-}
-
 .d2l-navigation-s-has-branding .d2l-navigation-main-ib {
 	border-top: 1px solid $d2l-color-light-galena;
 }
@@ -268,12 +264,6 @@ div.d2l-navigation-ib-item-icon-group-icon {
 	display: inline-block;
 }
 
-.d2l-navigation-s-no-branding
-.d2l-navigation-main-ib-tray[opened] > .d2l-navigation-main-ib-pully-container > .d2l-navigation-main-ib-bottom-cap {
-	border-top-color: $d2l-color-gypsum;
-}
-
-.d2l-navigation-s-no-branding,
 .d2l-navigation-s-linkarea-no-color {
 	.d2l-navigation-main-ib-bottom-cap {
 		border-bottom-color: $d2l-color-light-galena;
@@ -393,10 +383,6 @@ div.d2l-navigation-ib-item-icon-group-icon {
 
 .d2l-branding-navigation-light-foreground-color .d2l-navigation-main-ib-pully-icon > d2l-icon {
 	color: $d2l-branding-navigation-light-foreground-color;
-}
-
-.d2l-navigation-s-no-branding .d2l-navigation-main-ib-pully > d2l-icon {
-	color: $d2l-color-celestine;
 }
 
 .d2l-navigation-main-ib-tray[closing] .d2l-navigation-main-ib-pully[shown] .d2l-navigation-main-ib-pully-icon > d2l-icon {

--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -10,12 +10,6 @@
 }
 
 // remove this block (and m_daylightLinkAreaColorSwitch check in NavigationView.Renderer.cs ) in Nov 2018
-.d2l-navigation-s-no-branding .d2l-navigation-main-footer-container {
-	border-top: 1px solid $d2l-color-gypsum;
-	border-bottom: 1px solid $d2l-color-gypsum;
-}
-
-// remove this block (and m_daylightLinkAreaColorSwitch check in NavigationView.Renderer.cs ) in Nov 2018
 // add this style to the :host block in d2l-navigation-main-footer.html
 .d2l-navigation-s-has-branding .d2l-navigation-main-footer-container {
 	border-top: 1px solid $d2l-color-light-galena;
@@ -125,7 +119,6 @@
 	}
 }
 
-.d2l-navigation-s-no-branding,
 .d2l-navigation-s-linkarea-no-color {
 	.d2l-navigation-s-group:hover .d2l-navigation-s-group-text,
 	.d2l-navigation-s-group:focus .d2l-navigation-s-group-text,

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -70,10 +70,6 @@
 	font-weight: 700;
 }
 
-.d2l-navigation-s-no-branding .d2l-navigation-s-mobile-menu-header {
-	border-bottom: 1px solid $d2l-color-gypsum
-}
-
 .d2l-navigation-s-mobile-menu-color-strip {
 	border-top: 1px solid $d2l-color-light-galena;
 	border-bottom: 1px solid $d2l-color-light-galena;
@@ -154,10 +150,6 @@
 	}
 }
 
-.d2l-navigation-s-no-branding .d2l-navigation-s-mobile-menu-title-bp {
-	border-bottom: 1px solid $d2l-color-gypsum;
-}
-
 .d2l-navigation-s-has-branding .d2l-navigation-s-mobile-menu-title-bp {
 	border-top: 1px solid $d2l-color-light-galena;
 	border-bottom: 1px solid $d2l-color-light-galena;
@@ -168,7 +160,7 @@
 	margin: -7px;
 
 	.d2l-navigation-s-logo-divider {
-		display: inline-block;		
+		display: inline-block;
 	}
 
 	&.d2l-navigation-s-header-no-home-icon .d2l-navigation-s-logo-divider {


### PR DESCRIPTION
The code that put this CSS class on things [was removed](http://search.dev.d2l/source/diff/Lms/platformTools/navbars/D2L.PlatformTools.Navbars/Web/Desktop/Rendering/Views/Daylight/NavigationView.Renderer.cs?r2=%2FLms%2FplatformTools%2Fnavbars%2FD2L.PlatformTools.Navbars%2FWeb%2FDesktop%2FRendering%2FViews%2FDaylight%2FNavigationView.Renderer.cs%4084d0612c&r1=%2FLms%2FplatformTools%2Fnavbars%2FD2L.PlatformTools.Navbars%2FWeb%2FDesktop%2FRendering%2FViews%2FDaylight%2FNavigationView.Renderer.cs%4002c9f016), so there's no need for any CSS to target it.

I'll do a separate PR that also removes `d2l-navigation-s-has-branding` since it's now always present and so also doesn't need to be called out.