### PR TITLE
US102738-remove the no longer used css

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -79,10 +79,4 @@ a.d2l-navigation-s-link:visited {
 
 .d2l-navigation-s-title-container {
 	overflow: auto;
-
-	.d2l-navigation-s-course-info {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
 }

--- a/sass/navigation/mobile-menu.scss
+++ b/sass/navigation/mobile-menu.scss
@@ -192,15 +192,13 @@
 }
 
 .d2l-branding-navigation-dark-foreground-color {
-	.d2l-navigation-s-mobile-menu-title-bp,
-	.d2l-navigation-s-mobile-menu-title-bp .d2l-navigation-s-course-info {
+	.d2l-navigation-s-mobile-menu-title-bp  {
 		color: $d2l-branding-navigation-dark-foreground-color;
 	}
 }
 
 .d2l-branding-navigation-light-foreground-color {
-	.d2l-navigation-s-mobile-menu-title-bp,
-	.d2l-navigation-s-mobile-menu-title-bp .d2l-navigation-s-course-info {
+	.d2l-navigation-s-mobile-menu-title-bp {
 		color: $d2l-branding-navigation-light-foreground-color;
 	}
 }


### PR DESCRIPTION
Removed the code where `d2l-navigation-s-course-info` is applied, so the css is no longer used.