### PR TITLE
Pulling in d2l-activity-alignment-tags from d2l-activity-alignments

### DIFF
--- a/web-components/d2l-activity-alignments.js
+++ b/web-components/d2l-activity-alignments.js
@@ -1,2 +1,3 @@
 import 'd2l-activity-alignments/d2l-activity-alignments.js';
 import 'd2l-activity-alignments/d2l-select-outcomes.js';
+import 'd2l-activity-alignments/d2l-activity-alignment-tags.js';


### PR DESCRIPTION
I'm pretty sure this is all that's required to get `d2l-activity-alignment-tags` rendering in the LMS, but please correct me if I'm wrong.