### PR TITLE
only publishing if previous build steps have passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 script:
 - npm run test:ci
 - npm run build
-- 'if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "x$TRAVIS_TAG" != "x" ]; then npm run publish:cdn; fi'
+- 'if [ "$TRAVIS_TEST_RESULT" == "0"] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "x$TRAVIS_TAG" != "x" ]; then npm run publish:cdn; fi'
 env:
   global:
   # CDN_SECRET


### PR DESCRIPTION
Ran into this while working on the BSI improvements.

Basically while any step in the `script` block failing will fail the build, it doesn't prevent the subsequent steps from running. That's kind of what we want for the `test` and `build` bits... they can both run and fail, but we certainly don't want the deploy step to run if either of the previous two failed.

Another option is to move the publish into an `after_success` section, however then if it fails it doesn't fail the build... which we want.