### PR TITLE
Add a space to the new conditional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 script:
 - npm run test:ci
 - npm run build
-- 'if [ "$TRAVIS_TEST_RESULT" == "0"] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "x$TRAVIS_TAG" != "x" ]; then npm run publish:cdn; fi'
+- 'if [ "$TRAVIS_TEST_RESULT" == "0" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "x$TRAVIS_TAG" != "x" ]; then npm run publish:cdn; fi'
 env:
   global:
   # CDN_SECRET


### PR DESCRIPTION
There's been a quiet error message in recent travis builds for BSI: `/home/travis/.travis/functions: line 104: [: missing `]'`. It doesn't seem to cause a failure, but it's the only thing that stands out to me as why my tagged build didn't publish to cdn.

I'm hoping this fixes it.