### PR TITLE
[skip publish] temporarily fix

### DIFF
--- a/cli/autotag.js
+++ b/cli/autotag.js
@@ -49,7 +49,7 @@ async function tryGetActiveDevelopmentRelease() {
 	try {
 		releases = await rallyApi.query({
 			type: 'release',
-			limit: 1,
+			limit: 10,
 			fetch: ['Name'],
 			query: rally.util.query.where('ReleaseStartDate', '<=', nowISO).and('ReleaseDate', '>', nowISO).and('Project.Name', '=', 'D2L')
 		});
@@ -58,7 +58,7 @@ async function tryGetActiveDevelopmentRelease() {
 		process.exitCode = 1;
 		return null;
 	}
-	if (releases.TotalResultCount !== 1) {
+	if (releases.TotalResultCount === 0) {
 		console.error(chalk.red('    Error: Unable to query for active development release in Rally.'));
 		process.exitCode = 1;
 		return null;


### PR DESCRIPTION
It turns out `ReleaseStartDate` is the Last Call Date, so starting just now `20.19.6` is in range of our query, which is resulting in 2 releases coming back.

Temporary fix is to take the first one (which is `20.19.5`) just to get this working quickly for folks. I'm going to try and either sort them (so the first one is guaranteed to be the one we want) or look into querying milestones instead of releases.