### PR TITLE
[skip release] ordering the releases before taking the closest one

### DIFF
--- a/cli/autotag.js
+++ b/cli/autotag.js
@@ -51,6 +51,7 @@ async function tryGetActiveDevelopmentRelease() {
 			type: 'release',
 			limit: 10,
 			fetch: ['Name'],
+			order: 'ReleaseDate ASC',
 			query: rally.util.query.where('ReleaseStartDate', '<=', nowISO).and('ReleaseDate', '>', nowISO).and('Project.Name', '=', 'D2L')
 		});
 	} catch (e) {


### PR DESCRIPTION
Here's a more permanent fix for this. It orders the releases by dev-done date and picks the earliest one.