### PR TITLE
US105083 - Updating radius border from profile image icon in nav-bar

### DIFF
--- a/sass/navigation/personal-menu.scss
+++ b/sass/navigation/personal-menu.scss
@@ -13,7 +13,7 @@
 }
 
 .d2l-navigation-s-personal-menu-wrapper d2l-icon {
-	border-radius: 8px;
+	border-radius: 6px;
 	flex: 0 0 auto;
 	height: 42px;
 	overflow: hidden;
@@ -55,7 +55,7 @@
 .d2l-navigation-s-personal-menu-icon {
     align-items: center;
     background-color: $d2l-color-carnelian;
-    border-radius: 8px;
+    border-radius: 6px;
     display: inline-flex;
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;


### PR DESCRIPTION
* Should be 6px border radius to match spec for medium profile image http://design.d2l/components/profile-images/
* I think it was maybe missed at some point, the anonymous profile image seems to already be using 6px as well
* I have checked in with design

Adjustments for the part circled in red

![image](https://user-images.githubusercontent.com/1176292/56141637-32cdd380-5f6b-11e9-8bad-59cfc9f475d1.png)
