### PR TITLE
Fix Rally query

### DIFF
--- a/cli/autotag.js
+++ b/cli/autotag.js
@@ -21,7 +21,8 @@ const skipReleaseFlag = '[skip release]';
 
 async function tryGetActiveDevelopmentRelease() {
 
-	console.log('  Fetching active development release from Rally...');
+	console.log('Fetching active development release from Rally...');
+	console.group();
 
 	//  https://github.com/RallyTools/rally-node/wiki/User-Guide
 	const rallyApi = rally({
@@ -63,13 +64,15 @@ async function tryGetActiveDevelopmentRelease() {
 		return null;
 	}
 	if (releases.TotalResultCount === 0) {
-		console.error(chalk.red('    Error: Unable to query for active development release in Rally.'));
+		console.error(chalk.red('Error: Unable to query for active development release in Rally.'));
+		console.groupEnd();
 		process.exitCode = 1;
 		return null;
 	}
 
-	// If 2 releases are returned, it's the day of the switchover.
-	// - if it's before noon EST, we use the first release
+	// 2 releases can be returned as there's overlap between the active
+	// release's end date (ReleaseDate) and the next release's ReleaseStartDate
+	// (last call date).
 	let release = releases.Results[0];
 	console.log(`Found ${releases.TotalResultCount} candidate release(s).`);
 	if (releases.TotalResultCount === 2) {
@@ -89,7 +92,8 @@ async function tryGetActiveDevelopmentRelease() {
 
 	const match = rallyVersionChecker.exec(activeReleaseName);
 	if (!match) {
-		console.error(chalk.red(`    Error: Invalid Rally release name "${activeReleaseName}".`));
+		console.error(chalk.red(`Error: Invalid Rally release name "${activeReleaseName}".`));
+		console.groupEnd();
 		process.exitCode = 1;
 		return null;
 	}
@@ -101,7 +105,8 @@ async function tryGetActiveDevelopmentRelease() {
 	}
 	activeReleaseName = match[1] + monthPart;
 
-	console.log(chalk.green(`    Success! Active development release is: "${activeReleaseName}"`));
+	console.log(chalk.green(`Success! Active development release is: "${activeReleaseName}"`));
+	console.groupEnd();
 
 	return activeReleaseName;
 
@@ -139,13 +144,13 @@ async function tryFindMaxVersion(release) {
 		}
 	}
 
-	console.log(`  Maximum existing build for release "${release}" is "${maxVersion}".`);
+	console.log(`Maximum existing build for release "${release}" is "${maxVersion}".`);
 	return maxVersion;
 
 }
 
 async function createRelease(newTag) {
-	console.log(chalk.green(`  Creating release "${newTag}..."`));
+	console.log(chalk.green(`Creating release "${newTag}..."`));
 	try {
 		await gh.repos.createRelease({
 			'owner': owner,
@@ -163,28 +168,33 @@ async function createRelease(newTag) {
 async function main() {
 
 	console.log('Attempting to automatically tag BSI release...');
+	console.group();
 
 	const skipRelease = (process.env.TRAVIS_COMMIT_MESSAGE.toLowerCase().indexOf(skipReleaseFlag) > -1);
 	if (skipRelease) {
-		console.log(`  "${skipReleaseFlag}" present in commit message, aborting auto-tag.`);
+		console.log(`"${skipReleaseFlag}" present in commit message, aborting auto-tag.`);
+		console.groupEnd();
 		return;
 	}
 
 	const isTaggedCommit = (process.env.TRAVIS_TAG !== '');
 	if (isTaggedCommit) {
-		console.log('  Tagged commit, aborting auto-tag.');
+		console.log('Tagged commit, aborting auto-tag.');
+		console.groupEnd();
 		return;
 	}
 
 	const isPullRequest = (process.env.TRAVIS_PULL_REQUEST !== 'false');
 	if (isPullRequest) {
-		console.log('  Pull request, aborting auto-tag.');
+		console.log('Pull request, aborting auto-tag.');
+		console.groupEnd();
 		return;
 	}
 
 	const isFork = (process.env.TRAVIS_SECURE_ENV_VARS === 'false');
 	if (isFork) {
-		console.log('  Cannot publish from forks, aborting auto-tag.');
+		console.log('Cannot publish from forks, aborting auto-tag.');
+		console.groupEnd();
 		return;
 	}
 
@@ -193,16 +203,18 @@ async function main() {
 
 	let release;
 	if (isMaster) {
-		console.log('  Master branch detected.');
+		console.log('Master branch detected.');
 		release = await tryGetActiveDevelopmentRelease();
 		if (release === null) {
-			console.log('  Aborting auto-tag.');
+			console.log('Aborting auto-tag.');
+			console.groupEnd();
 			return;
 		}
 	} else {
-		console.log(`  Branch detected: "${branchName}".`);
+		console.log(`Branch detected: "${branchName}".`);
 		if (!versionChecker.test(branchName)) {
-			console.log(`  Branch name "${branchName}" not a valid version, aborting auto-tag.`);
+			console.log(`Branch name "${branchName}" not a valid version, aborting auto-tag.`);
+			console.groupEnd();
 			return;
 		}
 		release = branchName;
@@ -210,12 +222,14 @@ async function main() {
 
 	let maxVersion = await tryFindMaxVersion(release);
 	if (maxVersion === null) {
-		console.log('  Aborting auto-tag.');
+		console.log('Aborting auto-tag.');
+		console.groupEnd();
 		return;
 	}
 
 	const newTag = `v${release}-${++maxVersion}`;
 	createRelease(newTag);
+	console.groupEnd();
 
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1208,9 +1208,9 @@
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.8.tgz",
-      "integrity": "sha512-ffLNjJ7LVceAkjtDr26t4wQ7EvRfPQ+Jqzs0dgKOwrcgFLJYAMHfJecjYAK0A4ePJPeF60wmddAl1BAtWMLgdw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.9.tgz",
+      "integrity": "sha512-cYXFHTqwMOJUk2iUcMmNP/nM7kjQn0jHVcMYXzqecqmsb7XcGlOvHbV0GSVFsGqrH68DuikkJBdEUHCV5ZiKAw==",
       "dev": true
     },
     "abbrev": {
@@ -1451,9 +1451,9 @@
       "dev": true
     },
     "async-each": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-      "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
     "async-foreach": {
@@ -1889,6 +1889,15 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1960,14 +1969,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-      "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+      "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000955",
-        "electron-to-chromium": "^1.3.122",
-        "node-releases": "^1.1.13"
+        "caniuse-lite": "^1.0.30000960",
+        "electron-to-chromium": "^1.3.124",
+        "node-releases": "^1.1.14"
       }
     },
     "btoa-lite": {
@@ -2108,9 +2117,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000959",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000959.tgz",
-      "integrity": "sha512-6BvqmS0VLmY4sJCz6AbIJRQfcns8McDxi424y+3kmtisJeA9/5qslP+K8sqremDau7UU4WSsqdRP032JrqZY8Q==",
+      "version": "1.0.30000960",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz",
+      "integrity": "sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA==",
       "dev": true
     },
     "caseless": {
@@ -2362,9 +2371,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "concat-map": {
@@ -4480,6 +4489,12 @@
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
     "file-url": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
@@ -4547,12 +4562,12 @@
       }
     },
     "find-versions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
-      "integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
+      "integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
       "dev": true,
       "requires": {
-        "array-uniq": "^2.0.0",
+        "array-uniq": "^2.1.0",
         "semver-regex": "^2.0.0"
       },
       "dependencies": {
@@ -4777,14 +4792,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4862,12 +4877,12 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -5038,24 +5053,24 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.3",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5083,13 +5098,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5228,7 +5243,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -7509,9 +7524,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.14.tgz",
-      "integrity": "sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.15.tgz",
+      "integrity": "sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -22308,6 +22323,17 @@
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
+      }
+    },
+    "time": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/time/-/time-0.12.0.tgz",
+      "integrity": "sha1-dVQUvD7woupEzp93W9PPZk7Em7c=",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.0",
+        "debug": "^2.2.0",
+        "nan": "^2.2.0"
       }
     },
     "timed-out": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "sinon-chai": "^3.3.0",
     "susy": "^2.2.14",
     "svg2png": "^4.1.1",
+    "time": "^0.12.0",
     "uglify-js": "^3.4.7",
     "whatwg-fetch": "^3.0.0"
   }


### PR DESCRIPTION
This ended up being a super weird Rally bug. When we query Rally to find active releases using the current date, those queries don't seem to support passing in hours. So we can't rely on the query to filter the active release down for us.

I changed it so that the hours are zeroed out before the query, but then we'll get back the current and next release more often. I then use the current EST time to determine if the first release that comes back is still active and if it's past noon yet on release day.

I threw in `console.group()` to clean up the console logging a bit as I used it a lot to test this out.