### PR TITLE
Lock node version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: node
+node_js:
+- "11"
 sudo: false
 script:
 - npm run test:ci


### PR DESCRIPTION
Seems like Travis just turned their stable `node` version to version 12, which is causing lots of trouble.  Locking at version 11 for now to unblock other work, and we can investigate the issues with `node 12` (and the dreaded `npm 6.9.0`) tomorrow.