### PR TITLE
Apply cert fix US106128 to 20.19.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,7 +2575,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#1dc7ce1a95d0eb08fdeee125a64be7a4b95da100",
+      "version": "github:BrightspaceHypermediaComponents/activities#83fb487ed003923082ffba93826bc5d78d17f999",
       "from": "github:BrightspaceHypermediaComponents/activities#release/20.19.5",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Update commit hash: https://github.com/BrightspaceHypermediaComponents/activities/commit/83fb487ed003923082ffba93826bc5d78d17f999

https://github.com/BrightspaceHypermediaComponents/activities/pull/177