### PR TITLE
Fix Sequences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,14 +3278,14 @@
         "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-sequence-navigator": "github:BrightspaceHypermediaComponents/d2l-sequence-navigator#semver:^2",
-        "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
+        "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#release/20.19.5",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "polymer-frau-jwt": "github:Brightspace/polymer-frau-jwt#semver:^1"
       }
     },
     "d2l-sequences": {
       "version": "github:BrightspaceHypermediaComponents/sequences#97b87c9f4531addfaa8771eef1acc6543d9c9630",
-      "from": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
+      "from": "github:BrightspaceHypermediaComponents/sequences#release/20.19.5",
       "dev": true,
       "requires": {
         "@polymer/iron-collapse": "^3.0.0-pre.18",


### PR DESCRIPTION
I think this will solve the problem where npm i didn't seem to get the right version, causing polymer serve to fail on the release branch. After diffing what was in node_module/d2l-sequences and the sequences repo in the release/20.19.5 branch everything seemed to match