### PR TITLE
Bump simple-overlay version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2863,7 +2863,7 @@
       }
     },
     "d2l-card": {
-      "version": "github:BrightspaceUI/card#81307f0b4dc8e670f1356aacc031898e1dfb41f8",
+      "version": "github:BrightspaceUI/card#1c9c04d16808c431f71bf71d0d9cd0ef012d369f",
       "from": "github:BrightspaceUI/card#semver:^6",
       "dev": true,
       "requires": {
@@ -3048,7 +3048,7 @@
       }
     },
     "d2l-hypermedia-constants": {
-      "version": "github:Brightspace/d2l-hypermedia-constants#34a63c13d965fe44bc072fce6e5894a89f0a86f9",
+      "version": "github:Brightspace/d2l-hypermedia-constants#7eda7d9e48369511008b64c8ae119b278cb61eca",
       "from": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
       "dev": true
     },
@@ -3509,12 +3509,13 @@
       }
     },
     "d2l-simple-overlay": {
-      "version": "github:Brightspace/simple-overlay#53fe64eb74545e466e6be1f7c24a1c99e572e678",
+      "version": "github:Brightspace/simple-overlay#3af5d16779ae21bfe7e4fc92fd72ad27daafcdd5",
       "from": "github:Brightspace/simple-overlay#semver:^3",
       "dev": true,
       "requires": {
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
         "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",


### PR DESCRIPTION
- Fix Edge and IE11 if detached called twice
- Change to use `d2l-button-icon` (tested the monolith use with Manage Exemptions, looks good)