### PR TITLE
Updates to image-based nav for wcag 2.1

### DIFF
--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -161,7 +161,7 @@
 
 div.d2l-navigation-ib-item-icon-group-icon {
 	background-color: $d2l-color-sylvite;
-	border: 1px solid $d2l-color-gypsum;
+	border: 1px solid $d2l-color-mica;
 }
 
 .d2l-navigation-ib-item-group-content {

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -267,13 +267,13 @@ div.d2l-navigation-ib-item-icon-group-icon {
 	.d2l-navigation-main-ib-pully[shown]:focus,
 	.d2l-navigation-main-ib-pully[shown]:hover {
 		background-color: rgba(0,111,191,0.05);
-		border-color: rgba(0, 111, 191, 0.2);
+		border-color: $d2l-color-celestine;
 	}
 
 	.d2l-navigation-main-ib-pully[shown]:focus .d2l-navigation-main-ib-pully-icon,
 	.d2l-navigation-main-ib-pully[shown]:hover .d2l-navigation-main-ib-pully-icon {
 		background-color: rgba(0,111,191,0.05);
-		border-color: rgba(0, 111, 191, 0.2);
+		border-color: $d2l-color-celestine;
 	}
 }
 

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -265,15 +265,15 @@ div.d2l-navigation-ib-item-icon-group-icon {
 	}
 
 	.d2l-navigation-main-ib-pully[shown]:focus,
-	.d2l-navigation-main-ib-pully[shown]:hover {
+	.d2l-navigation-main-ib-pully[shown]:focus .d2l-navigation-main-ib-pully-icon {
 		background-color: rgba(0,111,191,0.05);
 		border-color: $d2l-color-celestine;
 	}
 
-	.d2l-navigation-main-ib-pully[shown]:focus .d2l-navigation-main-ib-pully-icon,
+	.d2l-navigation-main-ib-pully[shown]:hover,
 	.d2l-navigation-main-ib-pully[shown]:hover .d2l-navigation-main-ib-pully-icon {
 		background-color: rgba(0,111,191,0.05);
-		border-color: $d2l-color-celestine;
+		border-color: rgba(0, 111, 191, 0.2);
 	}
 }
 

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -52,8 +52,8 @@
 
 .d2l-navigation-ib-item-link {
 	background-color: transparent;
-	border-radius: 0.6rem;
-	border: 2px solid transparent;
+	border-radius: 0.7rem;
+	border: none;
 	box-sizing: border-box;
 	display: inline-block;
 	height: 6.05rem;
@@ -79,7 +79,8 @@
 }
 
 .d2l-navigation-ib-item-link:focus {
-	border-color: $d2l-color-celestine;
+	background-color: $d2l-color-gypsum;
+	box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 }
 
 .d2l-navigation-ib-item-icon,
@@ -102,11 +103,11 @@
 }
 
 .d2l-navigation-ib-item-custom-icon {
-	border-radius: 0.6rem;
+	border-radius: 0.7rem;
 }
 
 .d2l-navigation-ib-item-icon-group {
-	border-radius: 0.6rem;
+	border-radius: 0.7rem;
 	box-sizing: border-box;
 	display: flex;
 	flex-wrap: wrap;

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -52,7 +52,7 @@
 
 .d2l-navigation-ib-item-link {
 	background-color: transparent;
-	border-radius: 0.4rem;
+	border-radius: 0.6rem;
 	border: 2px solid transparent;
 	box-sizing: border-box;
 	display: inline-block;
@@ -102,11 +102,11 @@
 }
 
 .d2l-navigation-ib-item-custom-icon {
-	border-radius: 0.4rem;
+	border-radius: 0.6rem;
 }
 
 .d2l-navigation-ib-item-icon-group {
-	border-radius: 0.4rem;
+	border-radius: 0.6rem;
 	box-sizing: border-box;
 	display: flex;
 	flex-wrap: wrap;

--- a/sass/navigation/main-image-based.scss
+++ b/sass/navigation/main-image-based.scss
@@ -53,7 +53,7 @@
 .d2l-navigation-ib-item-link {
 	background-color: transparent;
 	border-radius: 0.4rem;
-	border: 1px solid transparent;
+	border: 2px solid transparent;
 	box-sizing: border-box;
 	display: inline-block;
 	height: 6.05rem;
@@ -74,18 +74,12 @@
 	padding-bottom: 0.5rem;
 }
 
-.d2l-navigation-ib-item-link:focus,
 .d2l-navigation-ib-item-link:hover {
-	background-color: rgba(0,111,191,0.05);
-}
-
-.d2l-navigation-ib-item-link:hover {
-	border-color: rgba(0, 111, 191, 0.2);
+	background-color: $d2l-color-gypsum;
 }
 
 .d2l-navigation-ib-item-link:focus {
-	border-color: rgba(0, 111, 191, 0.4);
-	box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+	border-color: $d2l-color-celestine;
 }
 
 .d2l-navigation-ib-item-icon,
@@ -198,7 +192,7 @@ div.d2l-navigation-ib-item-icon-group-icon {
 }
 
 .d2l-navigation-ib-item-link:hover .d2l-navigation-ib-item-link-text {
-	color: $d2l-color-celestine;
+	color: $d2l-color-celestine-minus-1;
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
Update the image based nav links hover and focus for wcag 2.1.  Group icon placeholder border darkened slightly so it still stands out against new hover background.

focused, normal, hovered
![ibn1](https://user-images.githubusercontent.com/9042472/58666156-8ff5cc80-8300-11e9-9054-1ea120e1c22a.png)

focused & hovered
![ibn2](https://user-images.githubusercontent.com/9042472/58666167-95ebad80-8300-11e9-88dd-eb70caa9aecf.png)

tray opener focused
![ibn3](https://user-images.githubusercontent.com/9042472/58666174-9a17cb00-8300-11e9-9492-10fda44d113e.png)


