### PR TITLE
Bump activities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,7 +2765,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#d5fb8a4e7faea381117b6f87a9c124bae0bf87b0",
+      "version": "github:BrightspaceHypermediaComponents/activities#696dfbc86e493d4a3b1c37dd52fa0edc0e7804d2",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bump activities to 3.2.3:
https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.2.3