### PR TITLE
add a blurb for resolving weirdness in package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ We use a `package-lock.json` file to lock our NPM dependencies. This ensures we 
 
 Any command that would normally add or update `package.json` will also update `package-lock.json` -- `npm install`, `npm update` etc. Just be cognizant of the changes you're making.
 
+### package-lock.json refresh
+
+Current versions of npm (6.8-6.10) do not always flatten package-lock.json with an `npm i`.  You may end up with many test errors like:
+
+```
+Polymer sub-dependency detected "d2l-organizations" in "d2l-activities". All Polymer dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.
+```
+
+If you've ensured that you aren't importing multiple versions, try the following:
+1) Windows: `ri ./node_modules -Recurse -Force` or *nix: `rm -rf ./node_modules`
+2) `rm package-lock.json`
+3) `npm i`
+
+This sequence will fully refresh your package-lock.json.
+
+
 [Read more in the `package-lock` documentation...](https://docs.npmjs.com/files/package-locks)
 
 ## Web Components

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We use a `package-lock.json` file to lock our NPM dependencies. This ensures we 
 
 Any command that would normally add or update `package.json` will also update `package-lock.json` -- `npm install`, `npm update` etc. Just be cognizant of the changes you're making.
 
-### package-lock.json refresh
+### `package-lock.json` Refresh
 
 Current versions of npm (6.8-6.10) do not always flatten package-lock.json with an `npm i`.  You may end up with many test errors like:
 


### PR DESCRIPTION
I was churning a good amount yesterday trying to figure out why npm i wasn't flattening properly, and found that i needed to go a bit nuclear.

Would this blurb in the readme be useful for anyone else? or is it fairly common knowledge?