### PR TITLE
Bump version for d2l-sequences and d2l-enrollments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3003,7 +3003,7 @@
       }
     },
     "d2l-enrollments": {
-      "version": "github:BrightspaceHypermediaComponents/enrollments#a0281c0acf1c77096c25d67e7e1f2ac2aa6fb04c",
+      "version": "github:BrightspaceHypermediaComponents/enrollments#c5fabd2f95c78d3e43168a686740c7319e212567",
       "from": "github:BrightspaceHypermediaComponents/enrollments#semver:^4",
       "dev": true,
       "requires": {
@@ -3569,7 +3569,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#49229086363be6ea44ec1764b337c04a3e7cd290",
+      "version": "github:BrightspaceHypermediaComponents/sequences#c40d534729c8b99455b3798a6c4b0e4c837c9a9f",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
# Changes
## d2l-enrollments
1. US107704: Add the context menu to the d2l-enrollment-hero-banner
1. DE34864: Fix the summary view meter bar to correctly fill in IE11
## d2l-sequences
1. DE34865: While in IE11, the Checkmark and Continue indicators are showing right next to Module titles.