### PR TITLE
bump activities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2854,6 +2854,7 @@
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
+        "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2831,7 +2831,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#61c608539795414cec0945b9ce5d621de9bd9603",
+      "version": "github:BrightspaceHypermediaComponents/activities#feea3519d3d9356c14a3d07f84072372f8606330",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Adding sort telemetry to activities

Hosted this branch locally and ensure that telemetry events are still being fired:

```
{"EventType":"TelemetryEvent","SourceId":"quick-eval","Date":"2019-07-11T22:35:55.309Z","EventBody":{"EventTypeGuid":"d6b021b6-ffa2-4ee8-8206-8710e04396ce","Action":"Sort","Custom":[{"name":"columnName","value":"courseName"},{"name":"sortDirection","value":"asc"}]},"name":"Sort","ts":1562884555}
```