### PR TITLE
removing unused dependencies on iron-icon and iron-iconset-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "@brightspace-ui/core": "^0.2",
     "@octokit/rest": "^16.19.0",
     "@polymer/esm-amd-loader": "^1.0.3",
-    "@polymer/iron-icon": "^3.0.0-pre.21",
-    "@polymer/iron-iconset-svg": "^3.0.1",
     "@polymer/lit-element": "^0.6.1",
     "@polymer/polymer": "^3.2.0",
     "@webcomponents/webcomponentsjs": "^2.0.4",

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -37,7 +37,6 @@ window.D2L.Telemetry = {
 	}
 };
 
-import '@polymer/iron-icon/iron-icon.js';
 import 'd2l-activities/components/d2l-quick-eval/d2l-quick-eval.js';
 import 'd2l-alert/d2l-alert-toast.js';
 import 'd2l-alert/d2l-alert.js';


### PR DESCRIPTION
This seems safe, but could use a second opinion.

`iron-iconset-svg` is no longer used in BSI (@dbatiste cleaned that up recently) and isn't used in the monolith. Ditto for `iron-icon`. This change resulted in no change to the `package-lock` file, which isn't surprising since other things inside BSI are still using them.

The only "risk" I can think of is that when `d2l-icons` stops pulling these in, then in theory if another dependency in BSI was using one of them but not importing it, it would break.