### PR TITLE
DE35087 - Disable Polymer's Synthetic Click Canceling

### DIFF
--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -80,6 +80,15 @@ import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import 'd2l-users/components/d2l-profile-image.js';
 
 import './navigation-icons.js';
+
+/*
+ * DE35087 - This was added by Polymer to handle ghost clicks in mobile browsers, but it has negative effects when using VoiceOver on iOS.
+ * Events were being incorrectly canceled, mostly affecting selecting radio buttons but other user actions as well.
+ * This line turns off this functionality.  See https://github.com/Polymer/polymer/issues/5289 for more info.
+ */
+import { setCancelSyntheticClickEvents  } from '@polymer/polymer/lib/utils/settings.js';
+setCancelSyntheticClickEvents(false);
+
 window.d2lWCLoaded = true;
 if (window.D2L.WebComponentsLoaded !== undefined) {
 	window.D2L.WebComponentsLoaded();


### PR DESCRIPTION
This turns off Polymer's ghost click handling, used for old mobile browsers.  This is causing issues selecting radio buttons in iOS with VoiceOver, because of the use of double-tap to select an option.

Based on my testing, turning this off doesn't seem to have any negative affects.  The PR that adds this fix (https://github.com/Polymer/polymer/pull/5533) for the Polymer issue (https://github.com/Polymer/polymer/issues/5289) mentions that this is not needed anymore and links to this article: https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away.  We are already adding `<meta name="viewport" content="width=device-width">` to the `head` like it suggests.

Aside from radio buttons, disabling this also fixes some other issues being caught by the same thing - for example, the client logo in the navbar was also having its click event cancelled with VoiceOver on about 50% of the time, and would just not do anything.