### PR TITLE
personal menu can soon be both d2l-icon and img

### DIFF
--- a/sass/navigation/personal-menu.scss
+++ b/sass/navigation/personal-menu.scss
@@ -12,7 +12,8 @@
 	display: flex;
 }
 
-.d2l-navigation-s-personal-menu-wrapper d2l-icon {
+.d2l-navigation-s-personal-menu-wrapper d2l-icon,
+.d2l-navigation-s-personal-menu-wrapper img {
 	border-radius: 6px;
 	flex: 0 0 auto;
 	height: 42px;


### PR DESCRIPTION
When we go to Lit, `<d2l-icon>` no longer supports the `src` attribute. This is used [in the LMS](https://github.com/Brightspace/lms/blob/35710600e328bbbe45a792d8ffc3371957d05a0f/platformTools/navbars/D2L.PlatformTools.Navbars/Web/Desktop/Rendering/Views/Daylight/PersonalMenuHandle.Renderer.cs#L94) in the old personal menu rendering code. This will be switching to just use an `img` tag instead, but that will need this CSS applied to it as well.