### PR TITLE
pulling in latest organizations and card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,9 +1405,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "version": "12.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
       "dev": true
     },
     "@types/resolve": {
@@ -2959,11 +2959,10 @@
       }
     },
     "d2l-card": {
-      "version": "github:BrightspaceUI/card#00f5132f8a78aa27c538205dc4cc034f7d956791",
+      "version": "github:BrightspaceUI/card#1a7818efed42d76a4e73be41cddbb10955732aa5",
       "from": "github:BrightspaceUI/card#semver:^6",
       "dev": true,
       "requires": {
-        "@polymer/iron-icon": "^3.0.1",
         "@polymer/polymer": "^3.0.0",
         "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
@@ -3400,12 +3399,11 @@
       "dev": true
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#f2f5d1b2d39898618dbd0289e9bbed35d73ab663",
+      "version": "github:BrightspaceHypermediaComponents/organizations#32d4e4b44b8237727620e81b99ccafa549e10735",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^0.2.1",
-        "@polymer/iron-icon": "^3.0.1",
         "@polymer/polymer": "^3.0.0",
         "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-course-image": "github:Brightspace/course-image#semver:^3",


### PR DESCRIPTION
These no longer use `iron-iconset-svg`, which means we can upgrade to Lit icons without issue.