### PR TITLE
Bump activities to 3.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2904,7 +2904,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#96259c38060ea2e2b4b7659dc519603445f8c0f8",
+      "version": "github:BrightspaceHypermediaComponents/activities#424366ded1a292adffb84be20d8dbbac6a358d8f",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.24.0

@dlockhart I can hold off on merging this until you give the go ahead - don't want to mess up your test