### PR TITLE
DE35555 - Add fix for duplicate my-courses cards into 20.19.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3434,7 +3434,7 @@
       }
     },
     "d2l-polymer-siren-behaviors": {
-      "version": "github:Brightspace/polymer-siren-behaviors#6555ed4f59e6fb60adeaf9b988acdf2314f077d6",
+      "version": "github:Brightspace/polymer-siren-behaviors#3899289c473bde7fb52de585cc10e88012b20a89",
       "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bump `d2l-polymer-siren-behaviors` to get the fix for the duplicate course cards in my-courses
No other changes had been made since: https://github.com/Brightspace/polymer-siren-behaviors/compare/6555ed4f59e6fb60adeaf9b988acdf2314f077d6..3899289c473bde7fb52de585cc10e88012b20a89