### PR TITLE
US109398 - Allow subtitle component to be used in BSI

### DIFF
--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -43,6 +43,7 @@ import '@brightspace-ui/core/components/button/floating-buttons.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/more-less/more-less.js';
 import 'd2l-activities/components/d2l-quick-eval/d2l-quick-eval.js';
+import 'd2l-activities/components/d2l-subtitle/d2l-subtitle.js';
 import '@d2l/switch/d2l-switch.js';
 import 'd2l-alert/d2l-alert-toast.js';
 import 'd2l-alert/d2l-alert.js';


### PR DESCRIPTION
Since there is a story to add this to BSI. My understanding is you want to write this component into the middle slot. Somewhere around https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/ImmersiveNav/ImmersiveNav.Renderer.cs?r=31480c86#66

Does that sound right?