### PR TITLE
Backport activities changes to 20.19.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2918,7 +2918,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#a90383d81e897b117d29339b3034a18f37ee9dd5",
+      "version": "github:BrightspaceHypermediaComponents/activities#49b665eed4d69fd4c2ec8d5ba60b12f4e72bb405",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
This contains:

* https://github.com/BrightspaceHypermediaComponents/activities/pull/314
* https://github.com/BrightspaceHypermediaComponents/activities/pull/315