### PR TITLE
US110531 - add quick eval fragment

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -20,7 +20,8 @@
     "web-components/d2l-outcomes-level-of-achievements.js",
     "web-components/d2l-outcomes-user-progress.js",
     "web-components/d2l-program-outcomes-picker.js",
-    "web-components/d2l-tabs.js"
+    "web-components/d2l-tabs.js",
+    "web-components/d2l-quick-eval.js"
   ],
   "extraDependencies": [
     "node_modules/d2l-rubric/editor/images/**",

--- a/web-components/d2l-quick-eval.js
+++ b/web-components/d2l-quick-eval.js
@@ -1,0 +1,1 @@
+import 'd2l-activities/components/d2l-quick-eval/d2l-quick-eval.js';


### PR DESCRIPTION
Problem: Quick Eval has problems when making API calls during page load
Problem: This was traced a race condition with d2lfetch auth
Problem: The root cause was because Quick Eval was being imported before d2lfetch auth was set up
Problem: Quick Eval is loaded on every single page that loads bsi
Solution: Integrate QE as a fragment instead

This is my attempt to do this without holding up BSI for the whole company.

First PR (this one): Add QE as a fragment, push BSI to LP
Second PR: Use QE fragment in LMS - this might cause QE to be loaded twice on the QE page but my assumption is that it will still work despite blowing up the console
Third PR: remove QE from bsi.js, push BSI to LP