### PR TITLE
Update Program Outcomes Picker to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3823,7 +3823,7 @@
       }
     },
     "d2l-program-outcomes-picker": {
-      "version": "github:Brightspace/program-outcomes-picker#c92cbd39cc28db4e4f24a6e20e8eda0a44806302",
+      "version": "github:Brightspace/program-outcomes-picker#57e05d833681478b177f43a72bdcbb7837742814",
       "from": "github:Brightspace/program-outcomes-picker#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Fills in stubbed out Lores API call for a real one now that Lores is updated