### PR TITLE
Add d2l-activities Serge JSON files dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -868,7 +868,7 @@
       }
     },
     "@d2l/audio": {
-      "version": "github:Brightspace/d2l-audio#e66feb688bc34e4a9fc573295a1accfe522a7580",
+      "version": "github:Brightspace/d2l-audio#ce6aeb909a5feb9a765fb2ec564b85ee6b2cf1e1",
       "from": "github:Brightspace/d2l-audio#semver:^3",
       "dev": true,
       "requires": {
@@ -885,7 +885,7 @@
       }
     },
     "@d2l/media-behavior": {
-      "version": "github:Brightspace/d2l-media-behavior#bcf72a7cc48f766cb52a2add3ed4b7cb2110cece",
+      "version": "github:Brightspace/d2l-media-behavior#8105ee13faf56edca5f7e8d913089622dfb76092",
       "from": "github:Brightspace/d2l-media-behavior#semver:^1",
       "dev": true,
       "requires": {
@@ -895,7 +895,7 @@
       }
     },
     "@d2l/seek-bar": {
-      "version": "github:Brightspace/d2l-seek-bar#dd6f619628e4ddaa6d807f9275a4cda1c271fbe3",
+      "version": "github:Brightspace/d2l-seek-bar#89ffcb054e3e3e3f308f9073627931f45d5d78b9",
       "from": "github:Brightspace/d2l-seek-bar#semver:^1",
       "dev": true,
       "requires": {
@@ -1573,9 +1573,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.10.tgz",
-      "integrity": "sha512-ObiPa43kJCkgjG+7usRCoxWhqKCmT5JWvi+8bg54KMkP2CvTliYLmKR9uHLaz+51JDOX/8MjWc6Xz18xHTs7XQ==",
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
     "@types/resolve": {
@@ -3216,7 +3216,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#da7590983d00d7dcf543698bde9c6c32bd820313",
+      "version": "github:BrightspaceHypermediaComponents/activities#1dcd5e89891ddb9643ed8b1a23b026f671ab7d46",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
@@ -3239,6 +3239,7 @@
         "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-save-status": "github:Brightspace/d2l-save-status#semver:^3",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
         "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
@@ -24631,13 +24632,13 @@
       }
     },
     "rollup": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.22.0.tgz",
-      "integrity": "sha512-x4l4ZrV/Mr/x/jvFTmwROdEAhbZjx16yDRTVSKWh/i4oJDuW2dVEbECT853mybYCz7BAitU8ElGlhx7dNjw3qQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.23.0.tgz",
+      "integrity": "sha512-/p72Z3NbHWV+Vi1p2X+BmPA3WqlZxpUqCy6E8U4crMohZnI+j9Ob8ZAfFyNfddT0LxgnJM0olO4mg+noH4SFbg==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
-        "@types/node": "*",
+        "@types/node": "^12.7.10",
         "acorn": "^7.1.0"
       },
       "dependencies": {

--- a/polymer.json
+++ b/polymer.json
@@ -26,6 +26,7 @@
     "web-components/d2l-quick-eval.js"
   ],
   "extraDependencies": [
+    "node_modules/d2l-activities/components/d2l-activity-editor/**/lang/*.json",
     "node_modules/d2l-rubric/editor/images/**",
     "node_modules/d2l-html-editor/skin-4.3.7/**",
     "node_modules/d2l-html-editor/langs/**",


### PR DESCRIPTION
An unforeseen result of the work done in https://github.com/BrightspaceHypermediaComponents/activities/pull/415, since `d2l-activities` is using `fetch` rather than `import` to fetch its translations, the BSI build ends up excluding the files from the build. Sadly, adding them to the `extraDependencies` in that repo isn't sufficient, and they still get skipped, whereas adding them here does work.

This is probably another small factor that leans us towards a better solution, possibly a build script - having to explicitly include each repo's JSON language files here would be pretty messy. This PR does get things back to working, though.