### PR TITLE
Fix BSI define error

### DIFF
--- a/cli/define-replacer.js
+++ b/cli/define-replacer.js
@@ -11,8 +11,9 @@
  * "window.define=", "window.define.", "window.define)" in esm-amd-loader.js
  * " define)define(" in shared_bundle_1.js from FastDom
  * "define(" at the start of each bundle file
+ * " define?define(" near the end of shared_bundle_1.js from babel (https://github.com/babel/babel/issues/10512)
  */
-const regex = /((\sdefine\)define\()|(window\.define=)|(window\.define\.)|(window\.define\))|^(define\())/g;
+const regex = /((\sdefine\)define\()|(\sdefine\?define\()|(window\.define=)|(window\.define\.)|(window\.define\))|^(define\())/g;
 
 module.exports = function(data) {
 	return data.replace(regex, (match) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.3.tgz",
-      "integrity": "sha512-kWKOEeuylpa781yCeA5//eEx1u3WtLZqbi2VWXLKmb3QDPb5T2f7Yk311MK7bvvjR70dluAeiu4VXXsG1WwJsw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.4.tgz",
+      "integrity": "sha512-tqrDyvPryBM6xjIyKKUwr3s8CzmmYidwgdswd7Uc/Cv0ogZcuS1TYQTLx/eWKP3UbJ6JxZAiYlBZabXm/rtRsQ==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.8",
@@ -18,7 +18,7 @@
         "mkdirp": "^0.5.1",
         "output-file-sync": "^2.0.0",
         "slash": "^2.0.0",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       }
     },
     "@babel/code-frame": {
@@ -31,15 +31,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.3.tgz",
-      "integrity": "sha512-QfQ5jTBgXLzJuo7Mo8bZK/ePywmgNRgk/UQykiKwEtZPiFIn8ZqE6jB+AnD1hbB1S2xQyL4//it5vuAUOVAMTw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.3",
+        "@babel/generator": "^7.6.4",
         "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.3",
+        "@babel/parser": "^7.6.4",
         "@babel/template": "^7.6.0",
         "@babel/traverse": "^7.6.3",
         "@babel/types": "^7.6.3",
@@ -49,7 +49,7 @@
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -70,15 +70,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.3.tgz",
-      "integrity": "sha512-hLhYbAb3pHwxjlijC4AQ7mqZdcoujiNaW7izCT04CIowHK8psN0IN8QjDv0iyFtycF5FowUOTwDloIheI25aMw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -296,9 +296,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.3.tgz",
-      "integrity": "sha512-sUZdXlva1dt2Vw2RqbMkmfoImubO0D0gaCrNngV6Hi0DA4x3o4mlrq0tbfY0dZEUIccH8I6wQ4qgEtwcpOR6Qg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -1904,9 +1904,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.545.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.545.0.tgz",
-      "integrity": "sha512-oQjpvvTkh2a7CvWhSUcFQWkpfkM3wVpzvLgGMInoZ6QIOsuQ+oNKz+zq48yQ619/GP8XnOh0zBQJLcYaa3XAKw==",
+      "version": "2.547.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.547.0.tgz",
+      "integrity": "sha512-SbFTTkxRMynrcDxXxWS3NxTbgpBhBDHKSQpP6Pd8qVIgul2uRjCE1YLk9dq1EXdY0ti8KmoLS9xY8R3CPjxLag==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -2756,6 +2756,14 @@
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "clean-css-cli": {
@@ -4639,9 +4647,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.279",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.279.tgz",
-      "integrity": "sha512-iiBT/LeUWKnhd7d/n4IZsx/NIacs7gjFgAT1q5/i0POiS+5d0rVnbbyCRMmsBW7vaQJOUhWyh4PsyIVZb/Ax5Q==",
+      "version": "1.3.280",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
+      "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -23802,6 +23810,12 @@
         "supports-color": "^6.1.0"
       },
       "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -25171,12 +25185,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -25275,9 +25283,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-resolve": {
@@ -25301,6 +25309,14 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -25979,6 +25995,14 @@
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
         "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "text-table": {
@@ -26270,6 +26294,12 @@
           "version": "2.20.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
           "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }


### PR DESCRIPTION
The latest version of babel is wrapping `define` even if we already wrap it: https://github.com/babel/babel/issues/10512.  This is now included in our `shared_bundle_1.js` file:
```
    "function" == typeof define ? define(function () {
        return exports
    }) : "object" == typeof module && (module.exports = exports)
```
This PR updates the regex of the replacer to catch and replace " define?define(" with " define2?define2(".

(I'm also updating the version of babel below, but that doesn't fix things.)