### PR TITLE
DE36611 - Bump organizations and get langterms for image banner for 20.19.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3540,7 +3540,7 @@
       }
     },
     "d2l-image-banner-overlay": {
-      "version": "github:Brightspace/d2l-image-banner-overlay#1830e009cad4e0d3b23916b6da3953203a90b4d7",
+      "version": "github:Brightspace/d2l-image-banner-overlay#9d32a32c5e8d258bdb836e7d233de318cd46e251",
       "from": "github:Brightspace/d2l-image-banner-overlay#semver:^4",
       "dev": true,
       "requires": {
@@ -3776,7 +3776,7 @@
       "dev": true
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#bf697036c10f8dad3e80a70934f292323e83f64d",
+      "version": "github:BrightspaceHypermediaComponents/organizations#155b969091a034b9478523be95f65b4c5404d6b7",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "dev": true,
       "requires": {


### PR DESCRIPTION
No changes have been made to `d2l-organizations` since the last update in 20.19.22, and the only changes to `d2l-image-banner-overlay` between the last version and this version were around the `package.json` file: https://github.com/Brightspace/d2l-image-banner-overlay/compare/1830e009cad4e0d3b23916b6da3953203a90b4d7..9d32a32c5e8d258bdb836e7d233de318cd46e251