### PR TITLE
Include d2l-organization-availability-set lang files in build

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -27,6 +27,7 @@
   ],
   "extraDependencies": [
     "node_modules/d2l-activities/components/d2l-activity-editor/**/lang/*.json",
+    "node_modules/d2l-organizations/components/d2l-organization-availability-set/lang/*.json",
     "node_modules/d2l-rubric/editor/images/**",
     "node_modules/d2l-html-editor/skin-4.3.7/**",
     "node_modules/d2l-html-editor/langs/**",


### PR DESCRIPTION
I am having the same problem that was described in this commit
https://github.com/Brightspace/brightspace-integration/commit/29df38ca5d6d5d785a1095381d7c064fa3cca866#diff-2d9e645fa178242a8fe6ccfbeafe0d20R29
because the localization file I am using in d2l-organization-availability-set is the same as the one from d2l-activity-editor in d2l-activities so I have the same issue.