### PR TITLE
updates to support new select styles in the HTML editor

### DIFF
--- a/sass/html-editor/group.scss
+++ b/sass/html-editor/group.scss
@@ -3,11 +3,7 @@
 
 .d2l-htmleditor-group {
 
-	border: 1px solid #D3D3D3;
-	border-radius: $vui-htmleditor-border-radius;
-	box-shadow: 0 1px 1px 0 #EFEFEF;
 	display: inline-block;
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#FFFFFF', endColorstr='#EEEEEE',GradientType=0 ); /* IE6-9 */
 	line-height: 1em;
 	margin-right: 0.3rem;
 
@@ -24,11 +20,25 @@
 	}
 
 	.d2l-htmleditor-toolbar-item {
-		.d2l-select {
-			border-radius: 0;
+		.d2l-select,
+		.d2l-select:hover:disabled {
+			border-color: #D3D3D3;
 		}
+		.d2l-select:hover, .d2l-select:focus {
+			border-color: $d2l-color-celestine;
+		}
+	}
+
+}
+
+.d2l-htmleditor-group-bordered {
+
+	border: 1px solid #D3D3D3;
+	border-radius: $vui-htmleditor-border-radius;
+	box-shadow: 0 1px 1px 0 #EFEFEF;
+
+	.d2l-htmleditor-toolbar-item {
 		&:first-child {
-			.d2l-select,
 			.d2l-htmleditor-button,
 			.d2l-menuflyout-opener {
 				border-top-left-radius: $vui-htmleditor-border-radius;
@@ -36,7 +46,6 @@
 			}
 		}
 		&:last-child {
-			.d2l-select,
 			.d2l-htmleditor-button {
 				border-top-right-radius: $vui-htmleditor-border-radius;
 				border-bottom-right-radius: $vui-htmleditor-border-radius;
@@ -49,7 +58,6 @@
 		}
 	}
 	[dir="rtl"] & .d2l-htmleditor-toolbar-item:first-child {
-		.d2l-select,
 		.d2l-htmleditor-button,
 		.d2l-menuflyout-opener   {
 			border-top-left-radius: 0;
@@ -59,7 +67,6 @@
 		}
 	}
 	[dir="rtl"] & .d2l-htmleditor-toolbar-item:last-child {
-		.d2l-select,
 		.d2l-htmleditor-button,
 		.d2l-menuflyout-opener {
 			border-top-right-radius: 0;

--- a/sass/html-editor/html-editor.scss
+++ b/sass/html-editor/html-editor.scss
@@ -7,7 +7,7 @@
 @import 'menu.scss';
 
 .d2l-htmleditor {
-	border: 1px solid #CCC;
+	border: 1px solid $d2l-color-galena;
 	border-radius: $vui-htmleditor-border-radius;
 	background-color: #FFF;
 }
@@ -46,24 +46,6 @@
 
 	.d2l-select-container {
 		margin: 0;
-		border: 0;
-		border-radius: 0;
-		padding: 0;
-	}
-
-	.d2l-select,
-	.d2l-select:hover,
-	.d2l-select:focus {
-		border: 0;
-		font-size: 0.7rem;
-		font-weight: normal;
-		padding: 0.4rem calc(1rem + 42px) 0.4rem 0.7rem;
-	}
-	[dir="rtl"] & .d2l-select,
-	[dir="rtl"] & .d2l-select:hover,
-	[dir="rtl"] & .d2l-select:focus {
-		padding-left: calc(1rem + 42px);
-		padding-right: 0.7rem;
 	}
 
 }

--- a/sass/html-editor/shared.scss
+++ b/sass/html-editor/shared.scss
@@ -1,3 +1,3 @@
-$vui-htmleditor-icon-height: 16px;
+$vui-htmleditor-icon-height: 18px;
 $vui-htmleditor-toolbar-height: 2rem;
 $vui-htmleditor-border-radius: 0.3rem;


### PR DESCRIPTION
Corresponding change coming in the LMS.

These changes support the concept of "bordered" HTML editor toolbar groups (all the existing ones) and non-bordered (`<select>`-based ones).

It also stops overriding the borders of `<select>`s (except toning down the colour to match the other items).