### PR TITLE
bringing back the "vui-input" class for UMD FRAs

### DIFF
--- a/sass/inputs.scss
+++ b/sass/inputs.scss
@@ -1,5 +1,6 @@
 @import '../node_modules/@brightspace-ui/core/components/inputs/input-select.scss';
 
-.d2l-select {
+.d2l-select,
+select.vui-input /* needed for some UMD FRAs */ {
 	@include d2l-input-select();
 }


### PR DESCRIPTION
Some UMD FRAs (like Awards) were depending on the `vui-input` CSS class to be present on the page in order to style `<select>`s and other things.

Correctly or incorrectly (I'd argue incorrectly as this was never how UMD FRAs were supposed to work), they're broken now. This is a relatively easy and painless fix to un-break them while still allowing us to remove the `vui-input` class from the MVC/legacy code and move forward.

I'm still going to make some improvements to Awards as I'm already in there.