### PR TITLE
Bump d2l-activities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3497,7 +3497,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#240f96738301df47bfe3c825ec6d4a864f1dcfa6",
+      "version": "github:BrightspaceHypermediaComponents/activities#75936e349f9c30fe2e0e3ab3901fcea84438cda3",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Siren SDK was already bumped in PR#1739. This updates d2l-activities to bring in the rest of the front end changes for US111803: https://rally1.rallydev.com/#/110294864140d/detail/userstory/349211942424