### PR TITLE
Bump d2l-activities, siren-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3502,7 +3502,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#e809de7a03f43b82f4031cb43c69962d392b99bd",
+      "version": "github:BrightspaceHypermediaComponents/activities#d82e90ab2e6bae5b9d164553453115830fca2658",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
@@ -25463,7 +25463,7 @@
       "dev": true
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#f0ed782dde847e2d419d0a324c9b7c681ed01817",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#3f04c010cdbce1a77653a2c0401430464a4a6074",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
This PR bumps d2l-activities (fyi @AllanKerr, @kieranderson) and siren-sdk (fyi @kieranderson) to get the date stuff and the turnitin stuff.