### PR TITLE
Don't allow incompatible npm versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -141,5 +141,8 @@
     "uglify-js": "^3.4.7",
     "whatwg-fetch": "^3.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "engines": {
+    "npm": "<=6.8.0"
+  }
 }


### PR DESCRIPTION
Node 6.8.0 is the  "preferred" version for BSI as higher versions can cause a variety of issues. Seems like this should be a hard limit to prevent people from experiencing unnecessary pain.

(Can surely squash if that causes some pain for you that I don't see, but seems to be a common question)