### PR TITLE
Fix FACE attachments

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -26,6 +26,7 @@
     "web-components/d2l-quick-eval.js"
   ],
   "extraDependencies": [
+    "node_modules/@d2l/d2l-attachment/locales/*.json",
     "node_modules/d2l-activities/components/d2l-activity-editor/**/lang/*.js",
     "node_modules/d2l-organizations/components/d2l-organization-availability-set/lang/*.js",
     "node_modules/d2l-rubric/editor/images/**",


### PR DESCRIPTION
Forgot that we need to include the langterm files explicitly here. Strangely, Chrome seems to still half-work without these, but Edge blows up entirely and doesn't work with attachments.