### PR TITLE
Explicitly include attachment icons

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -27,6 +27,7 @@
   ],
   "extraDependencies": [
     "node_modules/@d2l/d2l-attachment/locales/*.json",
+    "node_modules/@d2l/d2l-attachment/icons/*.svg",
     "node_modules/d2l-activities/components/d2l-activity-editor/**/lang/*.js",
     "node_modules/d2l-organizations/components/d2l-organization-availability-set/lang/*.js",
     "node_modules/d2l-rubric/editor/images/**",


### PR DESCRIPTION
Similar to #1770, but for icons this time! Need to explicitly include these are they are not `import`ed anywhere in Brightspace/attachments, but rather referenced using `resolveUrl`.