### PR TITLE
Backport refresh and langterms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,7 +3538,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#14837b219d751b430864f0c5f581f1aa403eafac",
+      "version": "github:BrightspaceHypermediaComponents/activities#c3646f03c7c5fc43edb6b5293d37cf8e1e5783f0",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bump activities to backport (or is it hotfix now) the refresh bugfix and langterms

https://github.com/BrightspaceHypermediaComponents/activities/compare/14837b219d751b430864f0c5f581f1aa403eafac...c3646f03c7c5fc43edb6b5293d37cf8e1e5783f0?w=1