### PR TITLE
upgrading to core 1.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -937,9 +937,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.27.0.tgz",
-      "integrity": "sha512-tEZdY0m0kysaGFaNFAGGyg1cddjmdcLB1bynnJu2BeNa6ENw88OSGHD2aJT1OhpY1GeJW/kfnccKsHmTVg0PcQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.28.0.tgz",
+      "integrity": "sha512-BzTGpf8WBGF3G3PpxCv9qsj8O4AJgQr0sSNBXjEWe61aGmgs45mdwfcnuYNO7UX8Gyjbov9mXOPmpzHFhXPY7w==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -1677,9 +1677,9 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.2.tgz",
-      "integrity": "sha512-OOpWfnOaveki8sI5MEY20jCxVuKTPpIYRGa5dkN3RwEHX6LZM3HwAsT4yalds5CZAGzkCnbnOUz8rxXIyTm2yQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.3.tgz",
+      "integrity": "sha512-lxys3KlfYU8LOGu7+UL2upa3kM9q8ISo4EK+vSqqJCLk6N74HsUZbUFiElolh4BUsv0jeMGtYDzpNrtrShE6Gg==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
@@ -3576,12 +3576,13 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#8ed5de1042d70965ded509bacb18c10b05a58d2d",
+      "version": "github:BrightspaceHypermediaComponents/activities#5d8da68ca8e2a56095643c040a8061550ae3a8c8",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/edit-in-place": "^1.0.7",
         "@brightspace-ui/core": "^1.17.0",
+        "@brightspace-ui/intl": "^3.0.1",
         "@d2l/d2l-attachment": "github:Brightspace/attachment#semver:^1",
         "@d2l/switch": "github:Brightspace/d2l-switch#semver:^3",
         "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
This picks up the version of core that doesn't have our Intl stuff in `LocalizeMixin`, as well as the version of activities that no longer uses them.