### PR TITLE
add node resolve config to favour es modules to fix commonjs import issues

### DIFF
--- a/es-dev-server.config.js
+++ b/es-dev-server.config.js
@@ -30,4 +30,19 @@ module.exports = {
 			return next();
 		}
 	],
+	nodeResolve: {
+		mainFields: ['jsnext:main', 'browser', 'module', 'main'],
+		// set default to false because es-dev-server always
+		// runs in the browser
+		preferBuiltins: true,
+		// will overwrite es-dev-server's fileExtensions option
+		extensions: ['.mjs', '.js'],
+		// will overwrite es-dev-server's dedupe option
+		dedupe: ['lit-html'],
+		customResolveOptions: {
+			// will overwrite es-dev-server's moduleDirs option
+			moduleDirectory: ['node_modules'],
+			preserveSymlinks: true,
+		},
+	}
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "autoprefix": "postcss ./build/bsi.css -o ./build/bsi.css -u autoprefixer",
-    "start": "cross-env BROWSERSLIST_CONFIG=./.browserslistrc-es-dev-server es-dev-server --config=./es-dev-server.config.js --compatibility auto --node-resolve --watch",
+    "start": "cross-env BROWSERSLIST_CONFIG=./.browserslistrc-es-dev-server es-dev-server --config=./es-dev-server.config.js --compatibility auto --watch",
     "build": "npm run build:wc && npm run build:common",
     "build-no-es5": "npm run build:wc-no-es5 && npm run build:common",
     "build:common": "npm run build:js && npm run build:sass && npm run build:icons && npm run build:navicons && npm run build:email-icons && npm run build:babelHelpers && npm run build:esm-amd-loader && npm run build:regenerator-runtime",


### PR DESCRIPTION
Copied from es-dev-server README but replaced deprecated jsnext/browser fields with mainFields.
https://github.com/open-wc/open-wc/tree/master/packages/es-dev-server#node-resolve
