### PR TITLE
Include the d2l-backdrop component.

### DIFF
--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -43,6 +43,7 @@ window.D2L.Telemetry = {
 	}
 };
 
+import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui/core/components/button/floating-buttons.js';


### PR DESCRIPTION
Include the `d2l-backdrop` component - to be used by ifrau (host) to place backdrop behind iframe when dialogs are open inside the iframe, although other things may use it in the future too.