### PR TITLE
bump sequence viewer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4411,7 +4411,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#c396c68c2d234e719c4a5f8d185d65c499efa68d",
+      "version": "github:Brightspace/d2l-sequence-viewer#2a17d24c7d4c988607d86c4e50edfc2d0879eaca",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
bumping to > https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v1.5.5