### PR TITLE
DE37638 - bump sequence viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,7 +4400,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#c396c68c2d234e719c4a5f8d185d65c499efa68d",
+      "version": "github:Brightspace/d2l-sequence-viewer#80507a98d72ffb2894bfa6c0379be76e51b17633",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Backporting to 20.20.2 
DE37638: (20.20.2) Cannot advance through activities/Survey on iPhone and Pulse App (Version 13.1.3)
Viewer version: https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v1.5.7