### PR TITLE
Bump d2l-rubric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4339,7 +4339,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#523756b5ae17843a9803e847e6006bfe5f1d2f57",
+      "version": "github:Brightspace/d2l-rubric#83720cebe5fac467f11f4f5f59b19c54498340be",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
[DE34471](https://rally1.rallydev.com/#/detail/defect/309752498680?fdp=true): Out of order points error message does not go away if you correct the point order by editing a cell that does not have the error associated with it