### PR TITLE
Learning Paths Cert Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3608,7 +3608,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#6ef28c27a99f8437ed9d1e56eda96b3a22aa59ef",
+      "version": "github:BrightspaceHypermediaComponents/activities#e438a55eb48368d5075c37ed3310ca0cfcabf8fe",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
@@ -3842,7 +3842,7 @@
       }
     },
     "d2l-enrollments": {
-      "version": "github:BrightspaceHypermediaComponents/enrollments#9bd05586c0b8cf35dd01483cea94cc0fafb904b7",
+      "version": "github:BrightspaceHypermediaComponents/enrollments#b866c14d4d13308cc2c6aaeeb9630ef1ced2a34a",
       "from": "github:BrightspaceHypermediaComponents/enrollments#semver:^4",
       "dev": true,
       "requires": {
@@ -4192,7 +4192,7 @@
       "dev": true
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#6762bdab3b3c4933aa6c7216a2fe27faff5455c4",
+      "version": "github:BrightspaceHypermediaComponents/organizations#f363a875f8677e9858c14f82b18286d791a7a5c4",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "dev": true,
       "requires": {


### PR DESCRIPTION
# Changes
This pull request includes cert fixes for the following repos:
- `d2l-activities`: https://github.com/BrightspaceHypermediaComponents/activities/tree/release/20.20.2
- `d2l-enrollments`: https://github.com/BrightspaceHypermediaComponents/enrollments/releases/tag/v4.0.34-cert
- `d2l-organizations`: https://github.com/BrightspaceHypermediaComponents/organizations/releases/tag/v5.1.59