### PR TITLE
Update sequence viewer version for DE37477

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4314,7 +4314,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#d9e1ed1af2ee454fa482c19e1518ddafe1e53673",
+      "version": "github:Brightspace/d2l-sequence-viewer#cf2ddaf88c21bf908674d6693570ddbc91e06fb8",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bumping to hotfix version for 20.20.1 https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v20.20.1-hotfix