### PR TITLE
Bump enrollments to include the My Courses lang term fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3842,7 +3842,7 @@
       }
     },
     "d2l-enrollments": {
-      "version": "github:BrightspaceHypermediaComponents/enrollments#2f48c2d39d291237680c8c14093dce275c8750a5",
+      "version": "github:BrightspaceHypermediaComponents/enrollments#740a9220eea99f0baa9e7575080830f97194ea20",
       "from": "github:BrightspaceHypermediaComponents/enrollments#semver:^4",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bump:
To: https://github.com/BrightspaceHypermediaComponents/enrollments/releases/tag/v4.0.34-cert5
From: https://github.com/BrightspaceHypermediaComponents/enrollments/releases/tag/v4.0.34-cert4