### PR TITLE
Bump enrollments for MyCourses lang term fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3967,7 +3967,7 @@
       }
     },
     "d2l-enrollments": {
-      "version": "github:BrightspaceHypermediaComponents/enrollments#fb623c49c71b4673c27af47633d5c506218abc38",
+      "version": "github:BrightspaceHypermediaComponents/enrollments#e0ac98e64eb823f7cfa986827df4d4fd8af73a09",
       "from": "github:BrightspaceHypermediaComponents/enrollments#semver:^4",
       "dev": true,
       "requires": {


### PR DESCRIPTION
I only bumped enrollments because of how close we are to branching since we may have to backport this version to 20.20.3 cert. These commit hashes for enrollments are sequential so the lang term fix is the only change.