### PR TITLE
moving uglifyjs build step into rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8250,6 +8250,33 @@
         "is-object": "^1.0.1"
       }
     },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -25449,6 +25476,18 @@
         }
       }
     },
+    "rollup-plugin-uglify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz",
+      "integrity": "sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^2.1.2",
+        "uglify-js": "^3.4.9"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -25788,6 +25827,12 @@
       "requires": {
         "semver": "^5.3.0"
       }
+    },
+    "serialize-javascript": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build-no-es5": "npm run build:wc-no-es5 && npm run build:common",
     "build:common": "npm run build:js && npm run build:sass && npm run build:icons && npm run build:navicons && npm run build:email-icons && npm run build:babelHelpers && npm run build:esm-amd-loader && npm run build:regenerator-runtime",
     "build:js": "rollup -c ./rollup/rollup.config.js",
-    "postbuild:js": "npm run uglify:js",
     "build:babelHelpers": "babel-external-helpers > ./build/babel-helpers.js",
     "build:esm-amd-loader": "cpy --cwd=node_modules/@polymer/esm-amd-loader/lib \"esm-amd-loader.min.js\" ../../../../build",
     "build:regenerator-runtime": "cpy --cwd=node_modules/regenerator-runtime/ \"runtime.js\" ../../build --rename=regenerator-runtime.js",
@@ -41,8 +40,7 @@
     "uglify:css": "npm run uglify:css:bsi && npm run uglify:css:datagrid && npm run uglify:css:homepages",
     "uglify:css:bsi": "cleancss ./build/bsi.css -o ./build/bsi.min.css",
     "uglify:css:datagrid": "cleancss ./build/datagrid.css -o ./build/datagrid.min.css",
-    "uglify:css:homepages": "cleancss ./build/homepages.css -o ./build/homepages.min.css",
-    "uglify:js": "uglifyjs ./build/bsi.js --compress --mangle --source-map \"content='build/bsi.js.map',url='bsi.min.js.map'\" -o ./build/bsi.min.js"
+    "uglify:css:homepages": "cleancss ./build/homepages.css -o ./build/homepages.min.css"
   },
   "repository": {
     "type": "git",
@@ -135,11 +133,11 @@
     "regenerator-runtime": "^0.13.2",
     "rimraf": "^2",
     "rollup": "^1",
+    "rollup-plugin-uglify": "^6",
     "sinon": "^7.2.2",
     "sinon-chai": "^3.3.0",
     "susy": "^2.2.14",
     "svg2png": "^4.1.1",
-    "uglify-js": "^3.4.7",
     "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {},

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -1,16 +1,24 @@
 import commonjs from '@rollup/plugin-commonjs';
+import { uglify } from 'rollup-plugin-uglify';
 
 const legacyConfig = {
 	input: './js/bsi.js',
 	plugins: [
 		commonjs()
 	],
-	output: {
-		dir: 'build',
-		format: 'iife',
-		name: 'BSI',
-		sourcemap: true
-	}
+	output: [
+		{
+			file: './build/bsi.js',
+			format: 'iife',
+			name: 'BSI'
+		},
+		{
+			file: './build/bsi.min.js',
+			format: 'iife',
+			name: 'BSI',
+			plugins: [uglify()]
+		}
+	]
 };
 
 export default legacyConfig;


### PR DESCRIPTION
Switches to use rollup for the uglify step of the `bsi.js` non-web-component JavaScript bundle.

I diff'ed these and the output is identical.

One change: I removed the generation of the source map file, since we don't actually publish any of the original source files to the CDN so the source map doesn't actually work anyway.