### PR TITLE
bump sequence viewer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4595,7 +4595,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#f499116f50896b6567f56182b090df15fa082aca",
+      "version": "github:Brightspace/d2l-sequence-viewer#471c6458e956952f2976e721cccee73890e95df2a",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Bumping to this version https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v1.5.10