### PR TITLE
DE38061 - bumping sequences for cert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,7 +4580,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#cf455c740e9dc229049c52bb9f2b5647d1d3e347",
+      "version": "github:BrightspaceHypermediaComponents/sequences#120a14fa9558dd01f7964b33801685c6b406130e",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Updating sequences to https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v1.5.5 to bring in the 20.20.3 translations