### PR TITLE
Remove sass file importing from the old icons repo

### DIFF
--- a/sass/deprecated/icons.scss
+++ b/sass/deprecated/icons.scss
@@ -1,5 +1,0 @@
-@import '../../node_modules/d2l-icons/icons.scss';
-
-.d2l-icon-custom {
-	@include d2l-icon();
-}

--- a/sass/vui.scss
+++ b/sass/vui.scss
@@ -1,5 +1,4 @@
 @import './deprecated/focus.scss';
-@import './deprecated/icons.scss';
 @import './deprecated/breadcrumbs.scss';
 @import './deprecated/button.scss';
 @import '../node_modules/jquery-vui-change-tracking/changeTracking.css.scss';


### PR DESCRIPTION
This css has been moved directly into the monolith.  This won't be merged until after https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/8947/overview is merged.