### PR TITLE
Bump rubrics and outcomes user progress for translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4487,7 +4487,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#b2f0a3833cb8406386d055de4dd836ab9d269978",
+      "version": "github:Brightspace/d2l-rubric#f738ed5186ada6f06b1b89df006c927746db7421",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,7 +4395,7 @@
       }
     },
     "d2l-outcomes-user-progress": {
-      "version": "github:Brightspace/d2l-outcomes-user-progress#49b6d5d40bf4d3a7a46bdaf3d4536a202f36bb3b",
+      "version": "github:Brightspace/d2l-outcomes-user-progress#24e43f4e1f1236b298e4b2eb06d439f695299a34",
       "from": "github:Brightspace/d2l-outcomes-user-progress#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
20.20.3 translations
Rubrics: https://github.com/Brightspace/d2l-rubric/releases/tag/v3.7.4
Outcomes-user-progress: https://github.com/Brightspace/d2l-outcomes-user-progress/releases/tag/v1.4.2