### PR TITLE
DE37820 - Fix selectivity of mobile inline dialog CSS

### DIFF
--- a/sass/dialog.scss
+++ b/sass/dialog.scss
@@ -314,7 +314,7 @@ html.d2l-dialog-open, html.d2l-dialog-open body {
 		position: fixed !important;
 	}
 
-	.d2l-dialog-inline {
+	.d2l-dialog-mvc.d2l-dialog-inline {
 		max-height: 100% !important;
 		max-width: 100%;
 	}


### PR DESCRIPTION
This fixes a regression on the selectivity of MVC inline dialogs on mobile - specifically, the width of the inline dialog should be `100%`, not `60vw`.