### PR TITLE
US111975 [SSR][Authors] Send alerts. Use new insights-portal icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,9 +1061,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.34.0.tgz",
-      "integrity": "sha512-2/YRpwWz9/YVV99CULyhzQT3KTF94JpjFAXpr162QKxL69GEfYMQ47V41kaqZmjmu54YCvVjSxK8Y+93A5ENlA==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.36.0.tgz",
+      "integrity": "sha512-xCRkoZ+NpvBI64r09PmJGi/HGyFElMzIHbyuvtrFqiZo3lLQq3A93YixnJEEyb7PTBuno7U2iqX1r1lN+GBL0Q==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
[US111975](https://rally1.rallydev.com/#/detail/userstory/351535324260?fdp=true): [SSR][Authors] Send alerts

This PR updates insights-portal.svg to fix cut-off version of icon

PR that added the icon https://github.com/BrightspaceUI/core/pull/421

`package-lock.json` diff is tiny for my change.