### PR TITLE
Force mobx library and base mobx lit element to be built as fragments…

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -28,7 +28,8 @@
     "web-components/d2l-content-store.js",
     "web-components/d2l-consistent-evaluation.js",
     "web-components/d2l-user-feedback.js",
-    "web-components/d2l-cpd-report.js"
+    "web-components/d2l-cpd-report.js",
+    "web-components/mobx.js"
   ],
   "extraDependencies": [
     "node_modules/@brightspace-ui-labs/edit-in-place/lang/*.js",

--- a/web-components/mobx.js
+++ b/web-components/mobx.js
@@ -1,0 +1,2 @@
+import('mobx');
+import('@adobe/lit-mobx');


### PR DESCRIPTION
… so they are not included in the shared bundle as this breaks IE11 even on pages where mobx is not used. Without this fix, MobX is being bundled in the Polymer build shared bundle because it is referenced by both the `d2l-activity-editor` and `d2l-consistent-evaluation` fragments. 

The mobx library has a rather draconian global scope check for support for JavaScript Symbol and Proxy, and throws an error if they are not defined. 

https://github.com/mobxjs/mobx/blob/master/src/v5/mobx.ts#L21

This completely breaks loading in IE11 on any page that loads the shared bundle (basically every page in the LMS).

By adding a new fragment to the polymer build that dynamically imports the mobx library and base mobx lit element, it causes the  polymer bundler to generate fragments for these libraries that are only referenced by other fragments that import these libraries, and so stops them from being included in the shared bundle.

I have only done basic testing of this fix in the activity editor (FACE). It needs more testing and should also be tested in consistent evalulation which is also using MobX.

If we agree this is an appropriate solution, I can work with someone on our team to get this fix backported into a 20.20.4 patch branch.

### Big Assumption? We don't care about supporting IE11 in these tools!

This is definitely the case for the `d2l-activity-editor` (FACE), but I'm not sure about `d2l-consistent-evaluation`? Maybe Alex or Dylan can confirm. Otherwise we may have to look at reverting at least consistent evaluation to MobX 4.