### PR TITLE
Cert fix: Force mobx library and base mobx lit element to be built as fragments…

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -28,7 +28,8 @@
     "web-components/d2l-content-store.js",
     "web-components/d2l-consistent-evaluation.js",
     "web-components/d2l-user-feedback.js",
-    "web-components/d2l-cpd-report.js"
+    "web-components/d2l-cpd-report.js",
+    "web-components/mobx.js"
   ],
   "extraDependencies": [
     "node_modules/@brightspace-ui-labs/edit-in-place/lang/*.js",

--- a/web-components/mobx.js
+++ b/web-components/mobx.js
@@ -1,0 +1,2 @@
+import('mobx');
+import('@adobe/lit-mobx');


### PR DESCRIPTION
… so they are not included in the shared bundle

Cert fix branch for #1959 