### PR TITLE
Add oslo to bsi build

### DIFF
--- a/.serge-mapping.json
+++ b/.serge-mapping.json
@@ -1,0 +1,17 @@
+{
+  "d2l-activities": "d2l-activities/activities.serge.json",
+  "d2l-activity-alignments": "d2l-activity-alignments/d2l-activity-alignments.serge.json",
+  "d2l-activity-exemptions": "d2l-activity-exemptions/d2l-activity-exemptions.serge.json",
+  "d2l-cpd": "d2l-cpd/continuous-professional-development.serge.json",
+  "d2l-enrollments": "d2l-enrollments/enrollments.serge.json",
+  "d2l-image-banner-overlay": "d2l-image-banner-overlay/imageBanner.serge.json",
+  "d2l-my-courses": "d2l-my-courses/d2l-my-courses.serge.json",
+  "d2l-navigation": "d2l-navigation/navigation.serge.json",
+  "d2l-organizations": "d2l-organizations/organizations.serge.json",
+  "d2l-outcomes-level-of-achievements": "d2l-outcomes-level-of-achievements/d2l-outcomes-level-of-achievements.serge.json",
+  "d2l-outcomes-user-progress": "d2l-outcomes-user-progress/d2l-outcomes-user-progress.serge.json",
+  "d2l-program-outcomes-picker": "d2l-program-outcomes-picker/program-outcomes-picker.serge.json",
+  "d2l-rubric": "d2l-rubric/d2l-rubric.serge.json",
+  "d2l-sequence-viewer": "d2l-sequence-viewer/d2l-sequence-viewer.serge.json",
+  "d2l-sequences": "d2l-sequences/d2l-sequences.serge.json"
+}

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ To integrate a new web component into BSI, perform the following steps:
 1. Reference your component as an NPM dependency using the path to the repository plus a semver tag (e.g. `"d2l-navigation": "BrightspaceUI/navigation#semver:^3"`). **Do not include minor or patch versions.**
 2. Add a JavaScript file (i.e. `d2l-my-component.js`) to the `web-components` directory that imports the new web component. (i.e. `../node_modules/my-component/my-component.js`)
 3. Reference the new JavaScript file from the fragments list in `polymer.json`
+4. (optional) If your component has langterms, add an entry to the `.serge-mapping.json` (e.g. `"my-component": "my-component/my-component.serge.json"`)
 
 ## Tagging & Publishing
 

--- a/oslo/.eslintrc.json
+++ b/oslo/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": "brightspace",
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
+  "rules": {
+    "no-console": 0
+  }
+}

--- a/oslo/Lang.js
+++ b/oslo/Lang.js
@@ -1,0 +1,17 @@
+'use strict';
+
+class Lang {
+
+	constructor(code, lang, culture) {
+		this.code = code;
+		this.lang = lang;
+		this.culture = culture;
+	}
+
+	toString() {
+
+		return this.code;
+	}
+}
+
+module.exports = Lang;

--- a/oslo/LangCollection.js
+++ b/oslo/LangCollection.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const LangObject = require('./LangObject');
+const Util = require('./Util');
+
+class LangCollection {
+
+	constructor(name) {
+		this._name = Util.escapeObjectName(name);
+		this._objects = new Map();
+	}
+
+	get name() {
+		return this._name;
+	}
+
+	get objects() {
+
+		return this._objects.values();
+	}
+
+	addObject(object) {
+
+		if (!(object instanceof LangObject)) {
+			throw new Error('Expected an instance of LangObject.');
+		}
+
+		if (this._objects.has(object.name)) {
+			throw new Error(
+				'Object "' + object.name + '" already present in the collection.'
+			);
+		}
+
+		this._objects.set(object.name, object);
+		return this;
+	}
+
+	getObject(name) {
+
+		return this._objects.get(name);
+	}
+
+	writeTo(serializer) {
+
+		serializer.writeTagBegin('collection');
+		serializer.writeAttribute('name', this._name);
+		serializer.writeAttribute('type', 'Standard');
+		serializer.writeTagBeginRightChar();
+		serializer.writeLine();
+		serializer.indent++;
+
+		const entries = Array.from(this._objects);
+
+		entries.sort(Util.byFirstArrayItem);
+
+		for (const [, object] of entries) {
+
+			object.writeTo(serializer);
+		}
+
+		serializer.indent--;
+		serializer.writeTagEnd('collection');
+		serializer.writeLine();
+	}
+}
+
+module.exports = LangCollection;

--- a/oslo/LangObject.js
+++ b/oslo/LangObject.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Util = require('./Util');
+
+class LangObject {
+
+	constructor(name, defaultValue, description) {
+
+		this._name = Util.escapeObjectName(name);
+		this._defaultValue = defaultValue;
+		this._description = description;
+	}
+
+	get name() {
+
+		return this._name;
+	}
+
+	get defaultValue() {
+
+		return this._defaultValue;
+	}
+
+	get description() {
+
+		return this._description;
+	}
+
+	writeTo(serializer) {
+
+		serializer.writeTagBegin('langTerm');
+		serializer.writeAttribute('sortOrder', '1');
+		serializer.writeAttribute('name', this._name);
+		serializer.writeTagBeginRightChar();
+		serializer.writeLine();
+		serializer.indent++;
+
+		serializer.writeFullTagBegin('defaultValue');
+		serializer.writeText(this._defaultValue);
+		serializer.writeTagEnd('defaultValue');
+		serializer.writeLine();
+
+		serializer.writeFullTagBegin('description');
+		serializer.writeText(this._description);
+		serializer.writeTagEnd('description');
+		serializer.writeLine();
+
+		serializer.indent--;
+		serializer.writeTagEnd('langTerm');
+		serializer.writeLine();
+	}
+}
+
+module.exports = LangObject;

--- a/oslo/LangPackage.js
+++ b/oslo/LangPackage.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const LangCollection = require('./LangCollection');
+const XmlSerializer = require('./XmlSerializer');
+const Util = require('./Util');
+
+class LangPackage {
+
+	constructor(name) {
+		this._name = Util.escapeObjectName(name);
+		this._collections = new Map();
+	}
+
+	get name() {
+		return this._name;
+	}
+
+	get collections() {
+
+		return this._collections.values();
+	}
+
+	addCollection(collection) {
+
+		if (!(collection instanceof LangCollection)) {
+			throw new Error('Expected an instance of LangCollection.');
+		}
+
+		if (this._collections.has(collection.name)) {
+			throw new Error(
+				'Collection "' + collection.name + '" already present in the package.'
+			);
+		}
+
+		this._collections.set(collection.name, collection);
+		return this;
+	}
+
+	getCollection(name) {
+
+		return this._collections.get(name);
+	}
+
+	writeTo(serializer) {
+
+		serializer.writeTagBegin('package');
+		serializer.writeAttribute('name', this._name);
+		serializer.writeAttribute('type', 'Language'); // Could be IcuLanguage?
+		serializer.writeAttribute('toolid', '0');
+		serializer.writeAttribute('version', '0.0.0.0');
+		serializer.writeTagBeginRightChar();
+		serializer.writeLine();
+		serializer.indent++;
+
+		const entries = Array.from(this._collections);
+
+		entries.sort(Util.byFirstArrayItem);
+
+		for (const [, collection] of entries) {
+
+			collection.writeTo(serializer);
+		}
+
+		serializer.indent--;
+		serializer.writeTagEnd('package');
+		serializer.writeLine();
+
+	}
+
+	toXML() {
+
+		const serializer = new XmlSerializer();
+		this.writeTo(serializer);
+		return serializer.toString();
+	}
+}
+
+module.exports = LangPackage;

--- a/oslo/Serge.js
+++ b/oslo/Serge.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const LangCollection = require('./LangCollection');
+const LangObject = require('./LangObject');
+const Util = require('./Util');
+
+const EmptyString = '';
+const MacroCulture = '%CULTURE%';
+const MacroLang = '%LANG%';
+const ParserPlugin = 'parse_json';
+const SourceLanguage = 'en';
+const SourceMatch = 'en\\.json$';
+
+const MacroRegExp = new RegExp('(' + MacroCulture + '|' + MacroLang + ')');
+const ParseJsRegExp = /^([^\S\r\n]*((['"]).+?\3|[\w\d]+)([^\S\r\n]*:[^\S\r\n]*))(?:(")((?:\\\\|\\"|[^"])+?)"|(')((?:\\\\|\\'|[^'])+?)')([^\S\r\n]*(?:,[^\S\r\n]*)?(?:\/\/[^\S\r\n]*(.*)[^\S\r\n]*)?)/mgi;
+const ParseJsNameRegExp = /["']/g;
+
+class Rewrite {
+
+	constructor(rewrite) {
+
+		this._rewrite = new Map();
+
+		if (!Array.isArray(rewrite)) {
+			return;
+		}
+
+		for (const entry of rewrite) {
+
+			const [from, to] = entry.split(' ');
+			this._rewrite.set(from, to);
+		}
+	}
+
+	get(from) {
+
+		return this._rewrite.get(from);
+	}
+
+	toObject() {
+
+		return Object.fromEntries(this._rewrite);
+	}
+}
+
+class Serge {
+
+	constructor(rootPath, moduleName, modulePath, sergeConfig) {
+
+		this._rootPath = rootPath;
+		this._name = Util.backSlash(path.join(moduleName, sergeConfig.name));
+		this._sourceDir = path.join(modulePath, sergeConfig.source_dir);
+		this._sourceLanguage = sergeConfig.source_language || SourceLanguage;
+		this._sourceMatch = new RegExp(sergeConfig.source_match || SourceMatch);
+		this._outputLangRewrite = new Rewrite(sergeConfig.output_lang_rewrite);
+		this._outputFilePath = path.join(modulePath, sergeConfig.output_file_path);
+		this._parserPlugin =
+			sergeConfig.parser_plugin &&
+			sergeConfig.parser_plugin.plugin ||
+			ParserPlugin;
+	}
+
+	get name() {
+
+		return this._name;
+	}
+
+	async getSource() {
+
+		try {
+
+			const entities = await fs.readdir(this._sourceDir, { withFileTypes: true });
+
+			for (const entity of entities) {
+
+				if (!entity.isFile()) {
+					continue;
+				}
+
+				if (!this._sourceMatch.test(entity.name)) {
+					continue;
+				}
+
+				const sourcePath = path.join(this._sourceDir, entity.name);
+				const sourceText = await fs.readFile(sourcePath, 'utf-8');
+
+				return this._parse(sourceText);
+			}
+
+			return null;
+
+		} catch (err) {
+
+			if (err.code === 'ENOENT') {
+				return null;
+			}
+
+			throw err;
+		}
+	}
+
+	async getTranslation(language) {
+
+		const sourcePath = this._outputFilePath.replace(MacroRegExp, (_, macro) => {
+
+			const rewrite = this._outputLangRewrite.get(language.code);
+			if (rewrite) {
+				return rewrite;
+			}
+
+			switch (macro) {
+
+				case MacroLang:
+					return language.lang;
+
+				case MacroCulture:
+					return language.culture;
+
+				default:
+					throw new Error(`Unsupported macro in "${this._name}" ("${macro}").`);
+			}
+		});
+
+		try {
+
+			const sourceText = await fs.readFile(sourcePath, 'utf-8');
+
+			return this._parse(sourceText);
+
+		} catch (err) {
+
+			if (err.code === 'ENOENT') {
+				return null;
+			}
+
+			throw err;
+		}
+	}
+
+	toManifest() {
+
+		const relativePath = path
+			.relative(this._rootPath, this._outputFilePath);
+
+		return {
+			name: this._name,
+			collectionName: Util.escapeObjectName(this._name),
+			resourcePath: Util.ForwardSlashChar + Util.forwardSlash(relativePath),
+			outputLangRewrite: this._outputLangRewrite.toObject(),
+			parserPlugin: this._parserPlugin
+		};
+	}
+
+	_parse(text) {
+
+		switch (this._parserPlugin) {
+
+			case 'parse_json':
+				return this._parseJson(text);
+
+			case 'parse_d2l_fra':
+				return this._parseFra(text);
+
+			case 'parse_js':
+				return this._parseJs(text);
+
+			default:
+				throw new Error(`Unsupported parser plugin for "${this._name}" ("${this._parserPlugin}")`);
+		}
+	}
+
+	_parseJson(text) {
+
+		const source = JSON.parse(text);
+		const entries = Object.entries(source);
+		const collection = new LangCollection(this._name);
+
+		for (const [name, defaultValue] of entries) {
+
+			const object = new LangObject(name, defaultValue, EmptyString);
+			collection.addObject(object);
+		}
+
+		return collection;
+	}
+
+	_parseFra(text) {
+
+		const source = JSON.parse(text);
+		const entries = Object.entries(source);
+		const collection = new LangCollection(this._name);
+
+		for (const entry of entries) {
+
+			const [name, {
+				context: description,
+				translation: defaultValue
+			}] = entry;
+
+			const object = new LangObject(name, defaultValue, description);
+			collection.addObject(object);
+		}
+
+		return collection;
+	}
+
+	_parseJs(text) {
+
+		const matches = text.matchAll(ParseJsRegExp);
+		const collection = new LangCollection(this._name);
+
+		for (const match of matches) {
+
+			const name = match[2].replace(ParseJsNameRegExp, '');
+			const defaultValue = match[6] || match[8];
+			const description = match[10] || EmptyString;
+
+			const object = new LangObject(name, defaultValue, description);
+			collection.addObject(object);
+		}
+
+		return collection;
+	}
+}
+
+module.exports = Serge;

--- a/oslo/Util.js
+++ b/oslo/Util.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const EscapeRegExp = /([^a-zA-Z0-9\\:_-])/g;
+const EscapeMap = new Map();
+const EscapeReplacer = (_, ch) => {
+
+	let replacement = EscapeMap.get(ch);
+	if (replacement === undefined) {
+		const charCode = ch.charCodeAt(0).toString(16).toUpperCase();
+		replacement = `\\u${charCode.padStart(4, '0')}`;
+		EscapeMap.set(ch, replacement);
+	}
+	return replacement;
+};
+
+function escapeObjectName(name) {
+
+	return name.replace(EscapeRegExp, EscapeReplacer);
+}
+
+function byFirstArrayItem(a, b) {
+
+	const [a0] = a;
+	const [b0] = b;
+
+	return a0 < b0 ? -1 : a0 > b0 ? 1 : 0;
+}
+
+const BackSlashChar = '\\';
+const BackSlashRegExp = /\\/g;
+const ForwardSlashChar = '/';
+const ForwardSlashRegExp = /\//g;
+
+function forwardSlash(value) {
+
+	return value.replace(BackSlashRegExp, ForwardSlashChar);
+}
+
+function backSlash(value) {
+
+	return value.replace(ForwardSlashRegExp, BackSlashChar);
+}
+
+exports.byFirstArrayItem = byFirstArrayItem;
+exports.escapeObjectName = escapeObjectName;
+exports.forwardSlash = forwardSlash;
+exports.backSlash = backSlash;
+exports.ForwardSlashChar = ForwardSlashChar;

--- a/oslo/XmlSerializer.js
+++ b/oslo/XmlSerializer.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const CDataLeftString = '<![CDATA[';
+const CDataRightString = ']]>';
+const DoubleQuoteChar = '"';
+const EolString = '\r\n';
+const EqualsDoubleQuoteString = '="';
+const IndentChar = ' ';
+const IndentSize = 2;
+const SlashChar = '/';
+const SpaceChar = ' ';
+const TagLeftChar = '<';
+const TagRightChar = '>';
+
+const EscapeMap = new Map([['"', '&quot;'], ['&', '&amp;'], ['<', '&lt;'], ['>', '&gt;'], ["'", '&apos;']]);
+const EscapeRegExp = /["'&<>]/g;
+const EscapeReplacer = (_, ch) => EscapeMap.get(ch);
+
+class XmlSerializer {
+
+	constructor() {
+
+		this._indent = 0;
+		this._result = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+		this._result += EolString;
+		this._shouldWriteIndent = false;
+	}
+
+	get indent() {
+
+		return this._indent;
+	}
+
+	set indent(value) {
+
+		this._indent = Math.max(0, value);
+	}
+
+	toString() {
+
+		return this._result;
+	}
+
+	writeTagBegin(tagName) {
+
+		this._writeIndent();
+		this._result += TagLeftChar;
+		this._result += tagName;
+	}
+
+	writeAttribute(name, value) {
+
+		this._writeIndent();
+		this._result += SpaceChar;
+		this._result += name;
+
+		if (typeof value === 'string' && value.length > 0) {
+
+			this._result += EqualsDoubleQuoteString;
+			this._result += this.escape(String(value));
+			this._result += DoubleQuoteChar;
+		}
+	}
+
+	writeTagBeginRightChar() {
+
+		this._writeIndent();
+		this._result += TagRightChar;
+	}
+
+	writeFullTagBegin(tagName) {
+
+		this._writeIndent();
+		this._result += TagLeftChar;
+		this._result += tagName;
+		this._result += TagRightChar;
+	}
+
+	writeText(text) {
+
+		this._writeIndent();
+		this._result += CDataLeftString;
+		if (typeof text === 'string' && text.length > 0) {
+			this._result += text;
+		}
+		this._result += CDataRightString;
+	}
+
+	writeTagEnd(tagName) {
+
+		this._writeIndent();
+		this._result += TagLeftChar;
+		this._result += SlashChar;
+		this._result += tagName;
+		this._result += TagRightChar;
+	}
+
+	writeLine() {
+
+		this._result += EolString;
+		this._shouldWriteIndent = true;
+	}
+
+	escape(value) {
+
+		return value.replace(EscapeRegExp, EscapeReplacer);
+	}
+
+	_writeIndent() {
+
+		if (this._shouldWriteIndent) {
+			this._result += IndentChar.repeat(this._indent * IndentSize);
+			this._shouldWriteIndent = false;
+		}
+	}
+}
+
+module.exports = XmlSerializer;

--- a/oslo/generate-monolith-xml
+++ b/oslo/generate-monolith-xml
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const Lang = require('./Lang');
+const LangPackage = require('./LangPackage');
+const Serge = require('./Serge');
+
+const Languages = [
+	new Lang('ar-sa', 'ar', 'ar-SA'),
+	new Lang('da-dk', 'da', 'da-DK'),
+	new Lang('de-de', 'de', 'de-DE'),
+	new Lang('es-mx', 'es', 'es-MX'),
+	new Lang('fr-ca', 'fr', 'fr-CA'),
+	new Lang('ja-jp', 'ja', 'ja-JP'),
+	new Lang('ko-kr', 'ko', 'ko-KR'),
+	new Lang('nl-nl', 'nl', 'nl-NL'),
+	new Lang('pt-br', 'pt', 'pt-BR'),
+	new Lang('sv-se', 'sv', 'sv-SE'),
+	new Lang('tr-tr', 'tr', 'tr-TR'),
+	new Lang('zh-cn', 'zh', 'zh-CN'),
+	new Lang('zh-tw', 'zh-TW', 'zh-TW'),
+];
+const PackageName = 'WebComponents';
+const TranslationReplacement = '%CULTURE:LC%';
+
+const DefinitionsPath = path.join(__dirname, '../build/langterms/definitions/', PackageName + '.xml');
+const ConfigPath = path.join(__dirname, '../build/langterms/D2L.LP.Oslo.config.json');
+const MappingPath = path.join(__dirname, '../.serge-mapping.json');
+const ModulesRoot = path.join(__dirname, '../node_modules');
+const TranslationPath = path.join(__dirname, '../build/langterms/translations/', TranslationReplacement, PackageName + '.xml');
+
+async function main() {
+
+	const mappingText = await fs.readFile(MappingPath, 'utf-8');
+	const mappingObject = JSON.parse(mappingText);
+	const mapping = Object.entries(mappingObject);
+
+	const definitions = new LangPackage(PackageName);
+	const manifest = [];
+	const translations = new Map();
+
+	for (const language of Languages) {
+		translations.set(language.code, new LangPackage(PackageName));
+	}
+
+	for (const [moduleName, sergeFile] of mapping) {
+
+		const modulePath = path.join(ModulesRoot, moduleName);
+		const sergePath = path.join(ModulesRoot, sergeFile);
+		const sergeText = await fs.readFile(sergePath, 'utf-8');
+		let sergeConfigs = JSON.parse(sergeText);
+
+		if (!Array.isArray(sergeConfigs)) {
+			sergeConfigs = [sergeConfigs];
+		}
+
+		for (const sergeConfig of sergeConfigs) {
+
+			const serge = new Serge(ModulesRoot, moduleName, modulePath, sergeConfig);
+
+			const collection = await serge.getSource();
+			if (!collection) {
+				throw new Error(`Could not load definitions for "${serge.name}".`);
+			}
+
+			definitions.addCollection(collection);
+
+			for (const language of Languages) {
+
+				const translation = translations.get(language.code);
+				const collection = await serge.getTranslation(language);
+				if (collection) {
+					translation.addCollection(collection);
+				}
+			}
+
+			manifest.push(serge.toManifest());
+		}
+	}
+
+	await fs.mkdir(path.dirname(DefinitionsPath), { recursive: true });
+	await fs.writeFile(DefinitionsPath, definitions.toXML());
+
+	for (const [language, translation] of translations) {
+
+		const translationPath = TranslationPath.replace(TranslationReplacement, language);
+
+		await fs.mkdir(path.dirname(translationPath), { recursive: true });
+		await fs.writeFile(translationPath, translation.toXML());
+	}
+
+	const configObject = {
+		packageName: PackageName,
+		manifest
+	};
+	const configText = JSON.stringify(configObject, null, 2);
+	await fs.mkdir(path.dirname(ConfigPath), { recursive: true });
+	await fs.writeFile(ConfigPath, configText);
+}
+
+main().catch(err => {
+
+	console.log(err);
+	process.exit(1);
+});

--- a/oslo/generate-serge-mapping
+++ b/oslo/generate-serge-mapping
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const Util = require('./Util');
+
+const ModulesRoot = path.join(__dirname, '../node_modules');
+const OutputPath = path.join(__dirname, '../.serge-mapping.json');
+const ScopePrefix = '@';
+const SergeSuffix = '.serge.json';
+
+async function main() {
+
+	const entries = [];
+	const candidates = [];
+	const nodeModules = await fs.readdir(ModulesRoot, { withFileTypes: true });
+
+	for (const nodeModule of nodeModules) {
+
+		if (nodeModule.isSymbolicLink()) {
+
+			const linkedPath = path.join(ModulesRoot, nodeModule.name);
+			const linkedModule = await fs.stat(linkedPath);
+			if (!linkedModule.isDirectory()) {
+				continue;
+			}
+
+		} else if (!nodeModule.isDirectory()) {
+
+			continue;
+		}
+
+		const moduleName = nodeModule.name;
+		const modulePath = path.join(ModulesRoot, moduleName);
+
+		if (moduleName.startsWith(ScopePrefix)) {
+
+			const subModules = await fs.readdir(modulePath, { withFileTypes: true });
+
+			for (const subModule of subModules) {
+
+				if (!subModule.isDirectory()) {
+					continue;
+				}
+
+				const subModuleName = path.join(moduleName, subModule.name);
+				const subModulePath = path.join(modulePath, subModule.name);
+				candidates.push([subModuleName, subModulePath]);
+			}
+
+		} else {
+
+			candidates.push([moduleName, modulePath]);
+		}
+	}
+
+	for (const [moduleName, modulePath] of candidates) {
+
+		const files = await fs.readdir(modulePath, { withFileTypes: true });
+
+		for (const file of files) {
+
+			if (!file.isFile()) {
+				continue;
+			}
+
+			const fileName = file.name;
+			if (!fileName.endsWith(SergeSuffix)) {
+				continue;
+			}
+
+			const filePath = path.join(modulePath, fileName);
+			const sergePath = path.relative(ModulesRoot, filePath);
+
+			entries.push([
+				Util.forwardSlash(moduleName),
+				Util.forwardSlash(sergePath)
+			]);
+		}
+	}
+
+	entries.sort(Util.byFirstArrayItem);
+
+	const mapping = Object.fromEntries(entries);
+	const mappingText = JSON.stringify(mapping, null, 2) + '\n';
+
+	await fs.writeFile(OutputPath, mappingText);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "cross-env BROWSERSLIST_CONFIG=./.browserslistrc-es-dev-server es-dev-server --config=./es-dev-server.config.js --compatibility auto --watch",
-    "build": "npm run build:wc && npm run build:common",
+    "build": "npm run build:wc && npm run build:common && npm run build:lang",
     "build-no-es5": "npm run build:wc-no-es5 && npm run build:common",
     "build:common": "rollup -c ./rollup/rollup.config.js && npm run build:babelHelpers",
     "build:babelHelpers": "babel-external-helpers > ./build/babel-helpers.js",
@@ -13,6 +13,8 @@
     "build:email-icons": "node ./cli/build-email-icons.js",
     "build:wc": "cross-env NODE_OPTIONS=--max_old_space_size=4096 polymer build",
     "build:wc-no-es5": "cross-env NODE_OPTIONS=--max_old_space_size=4096 polymer build --name \"es6-bundled\"",
+    "build:lang": "node ./oslo/generate-monolith-xml",
+    "build:serge-mapping": "node ./oslo/generate-serge-mapping",
     "postbuild": "npm run build:rename-define",
     "lint": "npm run lint:js",
     "lint:js": "eslint *.js web-components/*.js js/** rollup/** test/** cli/**",


### PR DESCRIPTION
This PR adds scripts the generates an XML language package for the included web components and a manifest for the Olso component in the LMS. The build artifacts will be committed into the monolith by the bsi-sync jenkins job.

We have a mapping file of component to serge file, which we then parse and traverse to discover all of the terms. We take care to encode the term names for the LMS, and to use a more or less stable identifier for the collection names so that components can be rejiggered (within reason...). This is similar to what RE's thing does, but less complicated because it doesn't actually implement any translation workflow.

Caveats: only works if the serge config is present in the node_modules directory, which happens to always be the case if it's a git dependency 🎉.