### PR TITLE
Bump d2l-rubric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4982,7 +4982,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#6cd07d1a2595d055c537974170d1854d9e32766f",
+      "version": "github:Brightspace/d2l-rubric#ff2d8b27362d523833ae62652c10389ccf7cd988",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
[DE38474](https://rally1.rallydev.com/#/detail/defect/379488800692?fdp=true): outcome picker in rubrics does not resize as the screen resizes
https://github.com/Brightspace/d2l-rubric/pull/650