### PR TITLE
Bump frau publisher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,9 +6882,9 @@
       }
     },
     "frau-publisher": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/frau-publisher/-/frau-publisher-2.7.11.tgz",
-      "integrity": "sha512-PyhdIKvPyQVuOPJjKJ8HhY4L+wHn41pO1+MDF1FQLRtBjIJZdEqaPzKqPC3KNHR0TWT6ctWgrL9Z73xpXuSoHQ==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/frau-publisher/-/frau-publisher-2.7.12.tgz",
+      "integrity": "sha512-UBcrPHrR217N/5bc/L/MCKn+JSUe46KrtnqnW8JWyU4h+JFhrCijAfrwYIPgXkbFAclwA4KxhywMcWNj0QzmIA==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2",


### PR DESCRIPTION
This PR bumps frau-publisher so that the language XML files are served with compression from the CDN.