### PR TITLE
removing regenerator-runtime from BSI bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "node-sass": "^4",
     "polymer-cli": "^1.9.8",
     "rally": "^2.1.3",
-    "regenerator-runtime": "^0.13.2",
     "rimraf": "^2",
     "rollup": "^1",
     "rollup-plugin-copy": "^3",

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -12,8 +12,7 @@ const jsConfig = {
 			targets: [
 				{src: 'node_modules/@brightspace-ui/core/components/icons/images', dest: './build'},
 				{src: 'email-icons', dest: './build/images'},
-				{src: 'node_modules/@polymer/esm-amd-loader/lib/esm-amd-loader.min.js', dest: './build'},
-				{src: 'node_modules/regenerator-runtime/runtime.js', dest: './build', rename: 'regenerator-runtime.js'}
+				{src: 'node_modules/@polymer/esm-amd-loader/lib/esm-amd-loader.min.js', dest: './build'}
 			]
 		})
 	],


### PR DESCRIPTION
DO NOT MERGE until [monolith PR merges](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/11005/overview).

Once renegerator-runtime is referenced from the CDN, we no longer need to publish it with each BSI bundle.