### PR TITLE
removing serve.bat batch file as it's redundant with "npm run serve"

### DIFF
--- a/serve.bat
+++ b/serve.bat
@@ -1,2 +1,0 @@
-rmdir "tmp" /s /q
-npm run serve


### PR DESCRIPTION
I reached out on #web-platform to see if anyone's relying on this and so far no one. I'd like for it to be gone as the concept of "serve" is going to change with the unbundled builds.