### PR TITLE
aligning browserlistrc files

### DIFF
--- a/.browserslistrc-es-dev-server-legacy
+++ b/.browserslistrc-es-dev-server-legacy
@@ -1,9 +1,0 @@
-last 2 Chrome major versions
-last 2 ChromeAndroid major versions
-last 2 Firefox major versions
-last 2 Edge major versions
-last 2 Safari major versions
-last 2 iOS major versions
-Firefox ESR
-ios_saf >= 10
-not dead

--- a/.browserslistrc-open-wc
+++ b/.browserslistrc-open-wc
@@ -1,6 +1,6 @@
 last 2 versions
 Firefox ESR
 Edge 18
-IE >= 11
+not IE 11
 ios_saf >= 10
 not dead

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preserve": "npm run build",
     "serve": "http-server build --cors",
     "start": "npm run start:legacy",
-    "start:legacy": "cross-env BROWSERSLIST_CONFIG=./.browserslistrc-es-dev-server-legacy es-dev-server --config=./es-dev-server-legacy.config.js --compatibility auto --watch",
+    "start:legacy": "cross-env BROWSERSLIST_CONFIG=./.browserslistrc-open-wc es-dev-server --config=./es-dev-server-legacy.config.js --compatibility auto --watch",
     "test": "npm run lint && npm run test:unit",
     "test:ci": "npm run test && npm run test:package-lock",
     "test:package-lock": "node test-package-lock.js",


### PR DESCRIPTION
Renaming the `es-dev-server` one as I want to use it for the new open-wc Rollup builds as well.

Also simplified it a bit so that it can be identical to the `.browserlistrc` except with the additional `not IE 11` (open-wc handles IE11 for us).