### PR TITLE
fixing warning for deprecated oktokit import method

### DIFF
--- a/cli/autotag.js
+++ b/cli/autotag.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const chalk = require('chalk'),
-	Octokit = require('@octokit/rest'),
+	{ Octokit } = require('@octokit/rest'),
 	rally = require('rally'),
 	moment = require('moment-timezone');
 


### PR DESCRIPTION
Was seeing this warning in the build output:
> [@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead