### PR TITLE
Updated activities to v3.52.176 and rubrics to v3.7.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5108,7 +5108,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#c95d03802653f3c3dfc1823561c1bc8cfa6701c0",
+      "version": "github:Brightspace/d2l-rubric#528896a2eacf808c6b574a7ba84e0951f34a98bf",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4281,7 +4281,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#4ba422bf1fda815639f82293fc8c8ea67c4244c4",
+      "version": "github:BrightspaceHypermediaComponents/activities#aadc1e4d0a8b378d2a390930aab43501d0ef4dec",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Updating to use this release of activities https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.52.176 and this release of rubrics https://github.com/Brightspace/d2l-rubric/releases/tag/v3.7.19