### PR TITLE
referencing alerts directly from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "d2l-activities": "BrightspaceHypermediaComponents/activities.git#semver:^3",
     "d2l-activity-alignments": "Brightspace/d2l-activity-alignments.git#semver:^2",
     "d2l-activity-exemptions": "Brightspace/d2l-activity-exemptions#semver:^2",
-    "d2l-alert": "BrightspaceUI/alert#semver:^4",
     "d2l-awards-leaderboard-ui": "Brightspace/awards-leaderboard-ui#semver:^1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -1,6 +1,8 @@
 import 'whatwg-fetch'; // Required for d2l-fetch + IE11
 import './bsi-unbundled.js';
 
+import '@brightspace-ui/core/components/alert/alert.js';
+import '@brightspace-ui/core/components/alert/alert-toast.js';
 import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/button/button-subtle.js';
@@ -26,8 +28,6 @@ import '@brightspace-ui/core/components/more-less/more-less.js';
 
 import 'd2l-activities/components/d2l-subtitle/d2l-subtitle.js';
 import '@d2l/switch/d2l-switch.js';
-import 'd2l-alert/d2l-alert-toast.js';
-import 'd2l-alert/d2l-alert.js';
 import 'd2l-button-group/d2l-action-button-group.js';
 import 'd2l-button-group/d2l-button-group.js';
 import 'd2l-navigation/d2l-navigation-band.js';


### PR DESCRIPTION
Shouldn't actually change anything, including `package-lock` since other projects are still referencing it.