### PR TITLE
adding unbundled alert assets

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -2,6 +2,8 @@ import { createBasicConfig } from '@open-wc/building-rollup';
 
 const componentFiles = [
 	'./web-components/bsi-unbundled.js',
+	'./node_modules/@brightspace-ui/core/components/alert/alert.js',
+	'./node_modules/@brightspace-ui/core/components/alert/alert-toast.js',
 	'./node_modules/@brightspace-ui/core/components/button/button-icon.js',
 	'./node_modules/d2l-navigation/d2l-navigation-band.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button-notification-icon.js',

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -3,7 +3,6 @@ import { createBasicConfig } from '@open-wc/building-rollup';
 const componentFiles = [
 	'./web-components/bsi-unbundled.js',
 	'./node_modules/@brightspace-ui/core/components/alert/alert.js',
-	'./node_modules/@brightspace-ui/core/components/alert/alert-toast.js',
 	'./node_modules/@brightspace-ui/core/components/button/button-icon.js',
 	'./node_modules/d2l-navigation/d2l-navigation-band.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button-notification-icon.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -10,6 +10,12 @@ import { announce } from '@brightspace-ui/core/helpers/announce';
 import { registerGestureSwipe } from '@brightspace-ui/core/helpers/gestures.js';
 import { clearDismissible, setDismissible } from '@brightspace-ui/core/helpers/dismissible';
 
+// Toast alerts are not a separate import for 3 reasons:
+// 1. Legacy toasts are created in JavaScript, so it would need to be loaded on every page anyway
+// 2. MVC toasts happen via RpcPiggyback, which can render before new BSI assets are loaded
+// 3. Quizzing is manually rendering a toast in JavaScript for offline/online notifications
+import '@brightspace-ui/core/components/alert/alert-toast.js';
+
 window.D2L = window.D2L || {};
 
 window.D2L.Intl = {

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -2,7 +2,6 @@ import 'whatwg-fetch'; // Required for d2l-fetch + IE11
 import './bsi-unbundled.js';
 
 import '@brightspace-ui/core/components/alert/alert.js';
-import '@brightspace-ui/core/components/alert/alert-toast.js';
 import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/button/button-subtle.js';


### PR DESCRIPTION
This is in preparation for using unbundled alerts and toasts. Unfortunately the toast import can't actually be unbundled for the reasons listed.