### PR TITLE
DE39183: update sequences and sequence viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5170,7 +5170,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#0afba63a59916a2a07ba938c5c43994a30283454",
+      "version": "github:Brightspace/d2l-sequence-viewer#d99fe0d291caff9499d5c26eac71ddf7c0c99f92",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {
@@ -5192,8 +5192,8 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#49a9aaaf1cafc750d2b6b31a75445930a6632ca7",
-      "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
+      "version": "github:BrightspaceHypermediaComponents/sequences#088d71f5a81c66eba19e294a8907bf49271ee416",
+      "from": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
This changes sequences to use [v1.15.16](https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v1.5.16) and sequence viewer to use [v1.7.2 ](https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v1.7.2)