### PR TITLE
[20.20.5] - DE39205 - Bump my-courses version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,8 +4786,8 @@
       }
     },
     "d2l-my-courses": {
-      "version": "github:Brightspace/d2l-my-courses-ui#734193e48da5ca457f9491c2dca01effa765a838",
-      "from": "github:Brightspace/d2l-my-courses-ui#v11.5.2-cert-fix-1",
+      "version": "github:Brightspace/d2l-my-courses-ui#46cd8d06e6fcbcb5530e84f2d1f9aaadcbf2ed9f",
+      "from": "github:Brightspace/d2l-my-courses-ui#v11.5.2-hot-fix-1",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "d2l-fetch-dedupe": "^1.1.0",
     "d2l-fetch-simple-cache": "^1.0.0",
     "d2l-image-banner-overlay": "Brightspace/d2l-image-banner-overlay#semver:^4",
-    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#v11.5.2-cert-fix-1",
+    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#v11.5.2-hot-fix-1",
     "d2l-my-dashboards": "github:Brightspace/d2l-my-dashboards-ui#semver:^3",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",


### PR DESCRIPTION
https://github.com/Brightspace/d2l-my-courses-ui/releases/tag/v11.5.2-hot-fix-1