### PR TITLE
[20.20.6] - DE39211 - Bump my-courses and core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,9 +1100,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.45.0.tgz",
-      "integrity": "sha512-u06gyudkyFjoPIIj2i6P8mG+uaOO84pK5T5bsjvL0mToFYYpQFhm4qCq9YdVVv+VkPU1FAWLCIQWsEwO8eMWtA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.45.1.tgz",
+      "integrity": "sha512-JxGNos1bB9/oU7BQMu7Lscb5dvoSj33mC6+7tRDLVgxnwXhpbnIUBP4qTZ7BpII569/D1K0+/iOXNdyXas04jg==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -4854,8 +4854,8 @@
       }
     },
     "d2l-my-courses": {
-      "version": "github:Brightspace/d2l-my-courses-ui#0d168c68b47497eb2dd4f22dd328c2b570d12f36",
-      "from": "github:Brightspace/d2l-my-courses-ui#semver:^11",
+      "version": "github:Brightspace/d2l-my-courses-ui#bcae03e74e7769ede72aad064a3a8b7aa358f476",
+      "from": "github:Brightspace/d2l-my-courses-ui#v11.10.0-cert-fix-1",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "d2l-fetch-dedupe": "^1.1.0",
     "d2l-fetch-simple-cache": "^1.0.0",
     "d2l-image-banner-overlay": "Brightspace/d2l-image-banner-overlay#semver:^4",
-    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#semver:^11",
+    "d2l-my-courses": "Brightspace/d2l-my-courses-ui#v11.10.0-cert-fix-1",
     "d2l-my-dashboards": "github:Brightspace/d2l-my-dashboards-ui#semver:^3",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",


### PR DESCRIPTION
This is the cert fix version of the fix to the all courses overlay issues in legacy edge.