### PR TITLE
updating script to also apply "dev" environment

### DIFF
--- a/unbundle-script/unbundle-tests.py
+++ b/unbundle-script/unbundle-tests.py
@@ -37,7 +37,8 @@ class TestUnbundler(unittest.TestCase):
         
         expected_data = {
             POLYMER: "",
-            IMPORT_STYLE: IMPORT_STYLE_ESM
+            IMPORT_STYLE: IMPORT_STYLE_ESM,
+            "env": "dev"
         }
 
         actual_data = {}

--- a/unbundle-script/unbundle.py
+++ b/unbundle-script/unbundle.py
@@ -83,6 +83,7 @@ class Unbundler:
 
                 data[POLYMER] = self.web_server_path
                 data[IMPORT_STYLE] = IMPORT_STYLE_ESM
+                data["env"] = "dev"
 
                 json.dump(data, data_file)
 


### PR DESCRIPTION
@DiljotSG would you be able to test this out for me? I run BSI from my Mac so the script itself doesn't work for me.

Essentially when the new unbundled builds are ready, `"env": "dev"` needs to get added to the monolith config file, which will do the same thing as `"import-style": "esm"` did. So this sets them both for now, and then when unbundled builds are always-on I'll remove the import-style stuff.