### PR TITLE
separating out the oslo lang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 before_install: if [[ `npm -v` != 6.8.0 ]]; then npm i -g npm@6.8.0; fi
 script:
 - npm run test:ci
-- travis_wait npm run build
+- travis_wait 30 npm run build
 - npm run build:lang
 - npm run build:unbundled
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install: if [[ `npm -v` != 6.8.0 ]]; then npm i -g npm@6.8.0; fi
 script:
 - npm run test:ci
 - travis_wait npm run build
+- npm run build:lang
 - npm run build:unbundled
 - |
   if [ "$TRAVIS_TEST_RESULT" == "0" ]; then

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build": "npm run build:legacy && npm run build:common",
-    "build:common": "rollup -c ./rollup/rollup.config.js && npm run build:lang",
+    "build:common": "rollup -c ./rollup/rollup.config.js",
     "build:legacy": "cross-env NODE_OPTIONS=--max_old_space_size=4096 polymer build && babel-external-helpers > ./build/babel-helpers.js && cpy \"node_modules/@polymer/esm-amd-loader/lib/esm-amd-loader.min.js\" \"build\" && node ./cli/rename-define.js \"./build/esm-amd-loader.min.js\" \"./build/es5-bundled/**/*.js\" \"./build/es6-bundled/**/*.js\"",
     "build:lang": "node ./oslo/generate-monolith-xml",
     "build:serge-mapping": "node ./oslo/generate-serge-mapping",


### PR DESCRIPTION
@kieranderson we chatted about this a couple weeks ago on Slack.

This breaks out the Oslo lang build step so that it only runs in CI, instead of each time a developer does a local build.