### PR TITLE
Reduce redundant Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - "12"
 sudo: false
+branches:
+  only:
+  - master
 # npm > 6.8.0 doesn't support our github semver references, so downgrade
 before_install: if [[ `npm -v` != 6.8.0 ]]; then npm i -g npm@6.8.0; fi
 script:


### PR DESCRIPTION
See [the docs](https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests)

It looks like each PR does two builds: one for the branch, and one for the PR event. This adds extra load on Travis and causes queuing.

We use this setting elsewhere, for example in [Brightspace/cdn-manager](https://github.com/Brightspace/cdn-manager/blob/master/.travis.yml#L6).

Give it some thought before merging. I don't know the particular details for this repo.