### PR TITLE
Disable dependabot for now

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"


### PR DESCRIPTION
It doesn't play well with the repos that are included as github urls.
They get bumped as casualties on random package bumps which isn't workable.

From @dlockhart : the PRs it generates have diffs like

```diff
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-        "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#a5dfce6568e1e13ac58895ef3bb47131f1342cd1",
+        "d2l-resize-aware": "github:BrightspaceUI/resize-aware#96ba3ac560380abfb753f128ac9a5c0992d7d723",
```

which won't work.

I'll turn on security alerts (not PRs) independently.