### PR TITLE
locking consistent-eval at 0.0.22 until they sort out their mobx issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4640,7 +4640,7 @@
     },
     "d2l-consistent-evaluation": {
       "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#5f22da0b2d50f41cecef19a99ca94cf19c132c20",
-      "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
+      "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#v0.0.22",
       "dev": true,
       "requires": {
         "@adobe/lit-mobx": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "d2l-activity-exemptions": "Brightspace/d2l-activity-exemptions#semver:^2",
     "d2l-awards-leaderboard-ui": "Brightspace/awards-leaderboard-ui#semver:^1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
-    "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
+    "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#v0.0.22",
     "d2l-content-store": "Brightspace/d2l-content-store#semver:^0",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^1",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",


### PR DESCRIPTION
This will prevent a recurrence of the mobx issues we were seeing this morning. Once consistent-eval is using `0.0.3` of mobx like the others, this can be unlocked again.