### PR TITLE
including mobx in the list of front-end dependencies we check against

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If this happens, you'll see this error in the browser console:
 
 BSI's CI attempts to detect this error by searching through the `package-lock` file for nested copies of the same thing. If it detects a duplicate, you'll get this CI failure:
 
-> Polymer sub-dependency detected "d2l-dependency" in "d2l-some-other-dependency". All Polymer dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.
+> Duplicate sub-dependency detected "d2l-dependency" in "d2l-some-other-dependency". All front-end dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.
 
 The most common cause of these errors is multiple projects referencing the same dependency via GitHub using different semver ranges in their `package.json` files. You can search the `package-lock.json` to find them. To solve the problem, ensure that all GitHub dependency references are identical.
 

--- a/test-package-lock.js
+++ b/test-package-lock.js
@@ -7,6 +7,9 @@ const path = require('path');
 
 const packageLockPath = path.join(__dirname, 'package-lock.json');
 const packages = [
+	'@adobe/lit-mobx',
+	'@brightspace-ui/core',
+	'@brightspace-ui/intl',
 	'd2l-fetch',
 	'd2l-fetch-auth',
 	'd2l-fetch-dedupe',
@@ -15,8 +18,7 @@ const packages = [
 	'd2l-organization-hm-behavior',
 	'd2l-polymer-siren-behaviors',
 	'd2l-telemetry-browser-client',
-	'@brightspace-ui/core',
-	'@brightspace-ui/intl'
+	'mobx'
 ];
 
 function validate(json, depth, parentKey) {
@@ -24,8 +26,9 @@ function validate(json, depth, parentKey) {
 	for (const key in json) {
 		if (depth > 1) {
 			const isPolymer = json[key].requires !== undefined && json[key].requires['@polymer/polymer'] !== undefined;
-			if (isPolymer || packages.indexOf(key) > -1) {
-				console.error(`Polymer sub-dependency detected "${key}" in "${parentKey}". All Polymer dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.`);
+			const isLit = json[key].requires !== undefined && (json[key].requires['lit-element'] !== undefined || json[key].requires['lit-html']);
+			if (isPolymer || isLit || packages.indexOf(key) > -1) {
+				console.error(`Duplicate dependency detected "${key}" in "${parentKey}". All front-end dependencies must be at root level of "package-lock.json" to avoid duplicate registrations. Check that the version ranges in "package.json" do not contain anything beyond the major version.`);
 				process.exitCode = 1;
 			}
 		}


### PR DESCRIPTION
This is draft for now as it's going to intentionally fail CI until `consistent-eval` is using the same version of mobx as everyone else. But had this check been in place, the issue never would have been introduced in the first place.

Update: everything is using the same mobx now, so should be good.