### PR TITLE
removing npmrc and nvmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,0 @@
-lts/erbium


### PR DESCRIPTION
These aren't needed now that we're unpinned from a specific NPM version.