### PR TITLE
unbundling save-status

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -19,6 +19,7 @@ const componentFiles = [
 	'./node_modules/d2l-navigation/d2l-navigation-main-header.js',
 	'./node_modules/d2l-navigation/d2l-navigation-separator.js',
 	'./node_modules/d2l-navigation/d2l-navigation.js',
+	'./node_modules/d2l-save-status/d2l-save-status.js',
 	'./node_modules/d2l-users/components/d2l-profile-image-base.js',
 	'./web-components/d2l-opt-in-flyout-webcomponent.js',
 	'./web-components/d2l-scroll-spy.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -80,8 +80,6 @@ import 'd2l-button-group/d2l-button-group.js';
 import 'd2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
 // CollapsibleSection (MVC), Homepages
 import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
-// SaveStatus (MVC)
-import 'd2l-save-status/d2l-save-status.js';
 
 window.D2L = window.D2L || {};
 

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -48,7 +48,7 @@ import 'd2l-navigation/d2l-navigation-separator.js';
 import 'd2l-navigation/d2l-navigation.js';
 //import 'd2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
 //import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
-//import 'd2l-save-status/d2l-save-status.js';
+import 'd2l-save-status/d2l-save-status.js';
 import 'd2l-users/components/d2l-profile-image.js';
 
 window.d2lWCLoaded = true;


### PR DESCRIPTION
This will have a corresponding change in the LMS, but will have to merge ahead of it to ensure that this asset is on the CDN for the LMS's asset verification tests to pass. In the interim, bundled builds will be fine but unbundled builds will just be missing the save-status indicator in quizzing -- which is OK for now since the feature flag is off.