### PR TITLE
unbundled consortium tabs

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -19,6 +19,7 @@ const componentFiles = [
 	'./node_modules/d2l-navigation/d2l-navigation-main-header.js',
 	'./node_modules/d2l-navigation/d2l-navigation-separator.js',
 	'./node_modules/d2l-navigation/d2l-navigation.js',
+	'./node_modules/d2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js',
 	'./node_modules/d2l-save-status/d2l-save-status.js',
 	'./node_modules/d2l-users/components/d2l-profile-image-base.js',
 	'./web-components/d2l-opt-in-flyout-webcomponent.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -76,8 +76,6 @@ import '@d2l/switch/d2l-switch.js';
 import 'd2l-button-group/d2l-action-button-group.js';
 // ActionButtons (legacy), GridActionContainer (MVC)
 import 'd2l-button-group/d2l-button-group.js';
-// OrganizationConsortiumTabs
-import 'd2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
 // CollapsibleSection (MVC), Homepages
 import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
 

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -46,7 +46,7 @@ import 'd2l-navigation/d2l-navigation-main-footer.js';
 import 'd2l-navigation/d2l-navigation-main-header.js';
 import 'd2l-navigation/d2l-navigation-separator.js';
 import 'd2l-navigation/d2l-navigation.js';
-//import 'd2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
+import 'd2l-organizations/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
 //import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
 import 'd2l-save-status/d2l-save-status.js';
 import 'd2l-users/components/d2l-profile-image.js';


### PR DESCRIPTION
Saves about `7 kB` from being downloaded, parsed and executed on every page. :)

Will require a change in the LMS but this needs to merge first. In the meantime, only the unbundled builds will be missing the consortium tabs.