### PR TITLE
unbundled switch

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -7,6 +7,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/alert/alert.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time.js',
 	'./node_modules/@brightspace-ui/core/components/button/button-icon.js',
+	'./node_modules/@d2l/switch/d2l-switch.js',
 	'./node_modules/d2l-navigation/d2l-navigation-band.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button-notification-icon.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -70,8 +70,6 @@ import '@brightspace-ui/core/components/more-less/more-less.js';
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
 // ImmersiveNav
 import 'd2l-activities/components/d2l-subtitle/d2l-subtitle.js';
-// LE ItemVisibility
-import '@d2l/switch/d2l-switch.js';
 // Grid (legacy)
 import 'd2l-button-group/d2l-action-button-group.js';
 // ActionButtons (legacy), GridActionContainer (MVC)

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -29,7 +29,7 @@ import '@brightspace-ui/core/components/alert/alert.js';
 //import '@brightspace-ui/core/components/tooltip/tooltip.js';
 
 //import 'd2l-activities/components/d2l-subtitle/d2l-subtitle.js';
-//import '@d2l/switch/d2l-switch.js';
+import '@d2l/switch/d2l-switch.js';
 //import 'd2l-button-group/d2l-action-button-group.js';
 //import 'd2l-button-group/d2l-button-group.js';
 import 'd2l-navigation/d2l-navigation-band.js';


### PR DESCRIPTION
Saves about `9 kB` from being downloaded, parsed & executed on every page. Only used once in the LMS -- PR there coming shortly but this will need to merge first.