### PR TITLE
explicitly including some components required by Capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "d2l-fetch-dedupe": "^1",
     "d2l-fetch-simple-cache": "^1",
     "d2l-image-banner-overlay": "Brightspace/d2l-image-banner-overlay#semver:^4",
+    "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "d2l-my-courses": "Brightspace/d2l-my-courses-ui#semver:^11",
     "d2l-my-dashboards": "github:Brightspace/d2l-my-dashboards-ui#semver:^3",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -42,6 +42,10 @@ import '@brightspace-ui/core/components/dropdown/dropdown.js';
 // Competencies (misc JS), Image (legacy), Grades (misc JS), Placeholder (legacy), PartialRendering,
 // Custom selector (legacy)
 import '@brightspace-ui/core/components/icons/icon.js';
+// VideoCapture
+import '@brightspace-ui/core/components/inputs/input-checkbox.js';
+// VideoCapture
+import '@brightspace-ui/core/components/inputs/input-text.js';
 // RubricBox
 import '@brightspace-ui/core/components/link/link.js';
 // Loading (MVC), PartialRendering, Dialog (MVC), Dialog (legacy)
@@ -60,6 +64,8 @@ import '@brightspace-ui/core/components/menu/menu-item.js';
 // EditNavbar, MobileLinksArea, HomepageManageMenu, PageActionsMenu, Menu (MVC), ContextMenu (MVC),
 // MediaPlayer, contextMenu (legacy), ActionButtons (legacy)
 import '@brightspace-ui/core/components/menu/menu.js';
+// VideoCapture
+import 'd2l-inputs/d2l-input-textarea.js';
 // CollapsibleSection (MVC), Homepages
 import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
 


### PR DESCRIPTION
This is a temporary measure until I can figure out a longer term solution to Capture using these custom elements -- either loading these modules from Capture, switching Capture to use something else, or wrapping them in MVC controls (which may not make sense).

Usages in Capture:
https://search.d2l.dev/xref/lms/mp/D2L.WCS.MP.Web/Controls/VideoCapture/VideoCapture.cs?r=8c179a86