### PR TITLE
Create trigger-lms-sync.yml

### DIFF
--- a/.github/workflows/trigger-lms-sync.yml
+++ b/.github/workflows/trigger-lms-sync.yml
@@ -1,0 +1,22 @@
+# This workflow triggers the LMS sync whenever there is a new BSI release
+
+name: LMS Sync
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  triggerSync:
+    runs-on: self-hosted
+
+    steps:
+    - name: Repository Dispatch
+      # will move this to Brightspace/third-party-actions once we know it's what we want
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repository: Brightspace/lms
+        event-type: bsi-sync
+        client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/trigger-lms-sync.yml
+++ b/.github/workflows/trigger-lms-sync.yml
@@ -19,4 +19,4 @@ jobs:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: Brightspace/lms
         event-type: bsi-sync
-        client-payload: '{"ref": "${{ github.ref }}"}'
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
This workflow should trigger a workflow in the `lms` repo on every bsi release. The lms workflow is TBD, but will be replacing the Jenkins jobs if all goes well.