### PR TITLE
Backport core 1.51.2 to 20.20.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.51.1.tgz",
-      "integrity": "sha512-i+kbsp3ujqFIJuLyW8KrBKA/uZgo8NKtasZYGBhaF3AOG/jxyg/eiVfCW5316e68p5+s7jbP0JyIbSjyxJq9pQ==",
+      "version": "1.51.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.51.2.tgz",
+      "integrity": "sha512-Ar76Xq1MFI3BkxzDjBIUUvgRxNgqOvUrPMUB6cExeJ0Tv7DKkozxgzjR+j5C6Np2GxLfoZGtwSI38fR+qnPePQ==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
# Changes
- Backport of this fix: https://github.com/BrightspaceUI/core/pull/640