### PR TITLE
DE39499 Cert 20.20.7: Update d2l-activities for translation updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4410,7 +4410,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#829a3cea8a4971a35599b1ac590c115c35e66a68",
+      "version": "github:BrightspaceHypermediaComponents/activities#c8e76bcf6e6e06a2028c94a64770f50560fe2241",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/activities/commits/release/20.20.7

https://rally1.rallydev.com/#/29180338367d/detail/defect/397885411452