### PR TITLE
DE39605: update sequence viewer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5170,7 +5170,7 @@
       }
     },
     "d2l-sequence-viewer": {
-      "version": "github:Brightspace/d2l-sequence-viewer#d99fe0d291caff9499d5c26eac71ddf7c0c99f92",
+      "version": "github:Brightspace/d2l-sequence-viewer#3f08d7e345f56d07a9bee6218be236e88bdc501d",
       "from": "github:Brightspace/d2l-sequence-viewer#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Backporting LX DocReader support

Bringing in this sequence-viewer release https://github.com/Brightspace/d2l-sequence-viewer/releases/tag/v1.7.2-hotfix