### PR TITLE
waiting for web fonts to be loaded before fading page in

### DIFF
--- a/js/bsi.js
+++ b/js/bsi.js
@@ -4,6 +4,7 @@ import './performance-timings.js';
 
 window.D2L = window.D2L || {};
 
+window.D2L.FontsLoaded = webComponentsReady.FontsLoaded;
 window.D2L.WebComponentsLoaded = webComponentsReady.WebComponentsLoaded;
 window.D2L.WCRDispatched = webComponentsReady.WCRDispatched;
 window.D2L.WebComponentsReady = webComponentsReady.WebComponentsReady;
@@ -12,4 +13,11 @@ if (window.d2lWCLoaded) {
 }
 if (window.d2lWCRDispatched) {
 	webComponentsReady.WCRDispatched();
+}
+if (window.d2lFontsLoaded) {
+	webComponentsReady.FontsLoaded();
+} else {
+	setTimeout(function() {
+		webComponentsReady.FontsLoaded();
+	}, 2000);
 }

--- a/js/d2l-web-components-ready.js
+++ b/js/d2l-web-components-ready.js
@@ -1,14 +1,19 @@
 var ready;
 var d2lComponentsLoaded = false;
 var webComponentsReady = false;
+var fontsLoaded = false;
 
 function check() {
-	if (d2lComponentsLoaded && webComponentsReady) {
+	if (d2lComponentsLoaded && webComponentsReady && fontsLoaded) {
 		ready();
 	}
 }
 
 export default {
+	FontsLoaded: function() {
+		fontsLoaded = true;
+		check();
+	},
 	WebComponentsLoaded: function() {
 		d2lComponentsLoaded = true;
 		check();

--- a/js/d2l-web-components-ready.js
+++ b/js/d2l-web-components-ready.js
@@ -27,6 +27,7 @@ export default {
 	}),
 	reset: function() {
 		d2lComponentsLoaded = false;
+		fontsLoaded = false;
 		webComponentsReady = false;
 		this.WebComponentsReady = new Promise(function(resolve) {
 			ready = resolve;

--- a/test/web-components-ready.js
+++ b/test/web-components-ready.js
@@ -16,6 +16,7 @@ describe('d2l-web-components-ready', () => {
 			wcr.WebComponentsReady.then(done);
 			wcr.WebComponentsLoaded();
 			wcr.WCRDispatched();
+			wcr.FontsLoaded();
 		});
 	});
 
@@ -24,6 +25,7 @@ describe('d2l-web-components-ready', () => {
 			done(new Error('should not be called'));
 		});
 		wcr.WebComponentsLoaded();
+		wcr.FontsLoaded();
 		done();
 	});
 
@@ -32,13 +34,24 @@ describe('d2l-web-components-ready', () => {
 			done(new Error('should not be called'));
 		});
 		wcr.WCRDispatched();
+		wcr.FontsLoaded();
 		done();
 	});
 
-	it('should execute after WebComponentsReady and WebComponentsLoaded', (done) => {
+	it('should not execute if no FontsLoaded', (done) => {
+		wcr.WebComponentsReady.then(() => {
+			done(new Error('should not be called'));
+		});
+		wcr.WebComponentsLoaded();
+		wcr.WCRDispatched();
+		done();
+	});
+
+	it('should execute after WebComponentsReady, WebComponentsLoaded and FontsLoaded', (done) => {
 		wcr.WebComponentsReady.then(done);
 		wcr.WCRDispatched();
 		wcr.WebComponentsLoaded();
+		wcr.FontsLoaded();
 	});
 
 	it('should execute all callbacks', (done) => {
@@ -60,6 +73,7 @@ describe('d2l-web-components-ready', () => {
 			count++;
 			check();
 		});
+		wcr.FontsLoaded();
 	});
 
 });


### PR DESCRIPTION
Corresponding PR in Brightspace:
https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/13415/overview

This change will delay the page "fade-in" until after our web fonts have loaded in browsers that support the FontFace API. It does so in a similar mechanism to how we wait for web components today. The hope is that this helps prevent a "flash of unstyled text" from occurring in some instances.

If things take too long (>2s), we assume something has gone wrong loading the fonts and we just fade-in regardless.