### PR TITLE
DE39554 - [NYU Accessibility: 2.1] Navigation > Accessibility > Top-Level Navbar > Focus Indicator too Subtle

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -54,7 +54,7 @@ a.d2l-navigation-s-link:visited {
 
 .d2l-navigation-s a.d2l-navigation-s-link:hover,
 .d2l-navigation-s a.d2l-navigation-s-link:focus {
-	text-decoration: underline;
+	border-bottom: 2px solid $d2l-color-celestine;
 	outline: none;
 }
 


### PR DESCRIPTION
[**DE39554**](https://rally1.rallydev.com/#/15545167705d/detail/defect/398847069340?fdp=true)

The following changes were made in this PR:
~ Replace text-decoration with a bottom border for navigation links

NOTE: In the demos below, I used the keyboard to navigate through the links, then used the cursor to hover over the links.

**Before:**
![DE39554-old](https://user-images.githubusercontent.com/52468104/87320505-0354a080-c4f9-11ea-9748-e93252bb394c.gif)

**After:**
![DE39554](https://user-images.githubusercontent.com/52468104/87320530-094a8180-c4f9-11ea-8b03-332430a9cb7a.gif)
