### PR TITLE
unbundling the backdrop component

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -6,6 +6,7 @@ import merge from 'deepmerge';
 const componentFiles = [
 	'./web-components/bsi-unbundled.js',
 	'./node_modules/@brightspace-ui/core/components/alert/alert.js',
+	'./node_modules/@brightspace-ui/core/components/backdrop/backdrop.js',
 	'./node_modules/@brightspace-ui/core/components/breadcrumbs/breadcrumb.js',
 	'./node_modules/@brightspace-ui/core/components/breadcrumbs/breadcrumb-current-page.js',
 	'./node_modules/@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -16,8 +16,6 @@ import { clearDismissible, setDismissible } from '@brightspace-ui/core/helpers/d
 import '@brightspace-ui/core/components/alert/alert-toast.js';
 
 // TODO: these still need to be unbundled and loaded individually whenever they're used
-// AppLoader
-import '@brightspace-ui/core/components/backdrop/backdrop.js';
 // PageActionsMenu, ContextMenuPlaceholder, ButtonIcon, RubricBox, MenuFlyout, Quizzing (misc JS),
 // legacy PageActions, legacy Grid actions, legacy ContextMenu placeholder, legacy Actions, Rubrics (misc JS)
 import '@brightspace-ui/core/components/button/button-icon.js';

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -5,7 +5,7 @@ import './bsi-unbundled.js';
 // but as they are each unbundled they'll need to return to
 // being imported here
 import '@brightspace-ui/core/components/alert/alert.js';
-//import '@brightspace-ui/core/components/backdrop/backdrop.js';
+import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumb.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumb-current-page.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js';


### PR DESCRIPTION
Will require the loading of this from the AppLoader, which will happen in a new iFRA plugin for the WC dialog.