### PR TITLE
bumping CPD to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4616,7 +4616,7 @@
       }
     },
     "d2l-cpd": {
-      "version": "github:Brightspace/continuous-professional-development#27e57b29d8b65d5cdeb25704a0667712c8f6d142",
+      "version": "github:Brightspace/continuous-professional-development#930c5ddcfb8d138cda4e76b36d27dd321797143d",
       "from": "github:Brightspace/continuous-professional-development#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Tested for correct commit hash by running `npm ci` after making my change.