### PR TITLE
unbundling the loading spinner

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -16,6 +16,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/inputs/input-search.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-text.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time.js',
+	'./node_modules/@brightspace-ui/core/components/loading-spinner/loading-spinner.js',
 	'./node_modules/@brightspace-ui/core/components/more-less/more-less.js',
 	'./node_modules/@brightspace-ui/core/components/switch/switch.js',
 	'./node_modules/@brightspace-ui/core/components/switch/switch-visibility.js',

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -41,8 +41,6 @@ import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 // RubricBox
 import '@brightspace-ui/core/components/link/link.js';
-// Loading (MVC), PartialRendering, Dialog (MVC), Dialog (legacy)
-import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 // MenuItemCheckbox
 import '@brightspace-ui/core/components/menu/menu-item-checkbox.js';
 // EditNavbar, NavbarItem, MenuItemLink, PageActionsMenuItem, HomepageManageMenu, ContextMenu

--- a/web-components/bsi.js
+++ b/web-components/bsi.js
@@ -21,7 +21,7 @@ import '@brightspace-ui/core/components/button/floating-buttons.js';
 //import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 //import '@brightspace-ui/core/components/link/link.js';
-//import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 //import '@brightspace-ui/core/components/menu/menu-item-checkbox.js';
 //import '@brightspace-ui/core/components/menu/menu-item-link.js';
 //import '@brightspace-ui/core/components/menu/menu-item-radio.js';


### PR DESCRIPTION
This saves about `1.5 kB` from each page. Corresponding PR in the monolith to dynamically load this in the few places that need it.