### PR TITLE
Update activities and siren-sdk versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4340,7 +4340,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#9cfef47067a247e1c5f6a8d27be641488c21674d",
+      "version": "github:BrightspaceHypermediaComponents/activities#a06c23b97506dc51675cafcdb512cc5a4472e6fc",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
@@ -26036,7 +26036,7 @@
       "dev": true
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#407a9d47d79845596d6e7254c6a1fa8915fa7242",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#a0580cbb0b04175c32c85358d2b60ff8443b338b",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26052,11 +26052,7 @@
       "dev": true
     },
     "siren-sdk": {
-<<<<<<< HEAD
       "version": "github:BrightspaceHypermediaComponents/siren-sdk#a0580cbb0b04175c32c85358d2b60ff8443b338b",
-=======
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#7f0e125273eb046f75159f7c7443203cad96b5ed",
->>>>>>> master
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Siren-sdk: https://github.com/BrightspaceHypermediaComponents/siren-sdk/releases/tag/v1.10.73
Activities: https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.52.251