### PR TITLE
Added patched version of core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.59.4",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.59.4.tgz",
-      "integrity": "sha512-TtiETYrmWVtvHOiSb8BJIkkcY4vHwWLXLF+LWGRGyIsj2MrskXudZDrYKtSFNCpB8U1hErb5FChXdomgFqeujg==",
+      "version": "1.59.5",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.59.5.tgz",
+      "integrity": "sha512-lrr0zdOv2AV709xTrm6eHHGYHbn90ORoxm4aVDe7yXftDyWmpoiTE5GLLeoukfmnqRiRmZAu8vSVsoMY1ChHzQ==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
- Pulls in a patch release version of `brightspace-ui/core` v1.59.5
  - [DE39813](https://rally1.rallydev.com/#/detail/defect/405152852372?fdp=true): Dragging and dropping a list item in a Learning Path intermittently redirects to a Google search for "undefined" on iPad Safari
  - Show drag handle on touch devices
  - Adds drag n drop support for touch devices
  - Lint fixes