### PR TITLE
removing d2l-link

### DIFF
--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -39,8 +39,6 @@ import '@brightspace-ui/core/components/dropdown/dropdown.js';
 // Competencies (misc JS), Image (legacy), Grades (misc JS), Placeholder (legacy), PartialRendering,
 // Custom selector (legacy)
 import '@brightspace-ui/core/components/icons/icon.js';
-// RubricBox
-import '@brightspace-ui/core/components/link/link.js';
 // MenuItemCheckbox
 import '@brightspace-ui/core/components/menu/menu-item-checkbox.js';
 // EditNavbar, NavbarItem, MenuItemLink, PageActionsMenuItem, HomepageManageMenu, ContextMenu


### PR DESCRIPTION
I removed the one place in the monolith that was using a `<d2l-link>` web component yesterday as [part of this PR](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/14059/overview). That means we no longer need to include it on every page! 🎉 