### PR TITLE
dnd-sortable bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,7 +4563,7 @@
       }
     },
     "d2l-dnd-sortable": {
-      "version": "github:Brightspace/dnd-sortable#38bc8fc34b0e2d8b8faf2e35514eb002fc2e2bbc",
+      "version": "github:Brightspace/dnd-sortable#f2682f9fa8b35deaee603a72a332687ca80ae83e",
       "from": "github:Brightspace/dnd-sortable#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Context:
DE39798
Fixed js error thrown in Edge when attaching a new rubric
updated d2l-dnd-sortable.js

