### PR TITLE
DE39554 (Certfix) - [NYU Accessibility: 2.1] Navigation > Accessibility > Top-Level Navbar > Focus Indicator too Subtle

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -54,7 +54,7 @@ a.d2l-navigation-s-link:visited {
 
 .d2l-navigation-s a.d2l-navigation-s-link:hover,
 .d2l-navigation-s a.d2l-navigation-s-link:focus {
-	border-bottom: 2px solid $d2l-color-celestine;
+	border-bottom: 2px solid;
 	outline: none;
 }
 

--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -104,7 +104,7 @@
 	}
 	&:hover .d2l-navigation-s-group-text,
 	&:focus .d2l-navigation-s-group-text {
-		text-decoration: underline;
+		border-bottom: 2px solid;
 	}
 }
 


### PR DESCRIPTION
### [DE39554 (certfix)](https://rally1.rallydev.com/#/15545167705d/custom/21568985922?detail=%2Fdefect%2F398847069340&fdp=true)

This defect required a certfix because of two things:
~ the colour for the underline on navigation links was always `d2l-color-celestine` regardless of the colour of the link text itself
~ the navigation links that were dropdowns were still using the old styling (i.e. using text-decoration instead of the thicker border-bottom)

The following changes were made in this PR:
~ removed colour from border-bottom property for navigation links (colour will be inherited now)
~ replaced text-decoration with a thicker border-bottom for navigation links that are dropdowns

***

**Before:**
NOTE: Used Spark to show the issue with underline colour.
![DE39554-cf-before](https://user-images.githubusercontent.com/52468104/88434626-9382c780-cdce-11ea-94c3-3aa110e9290f.gif)

***

**After:**
NOTE: Applied the same colour (using navbar themes) on my local instance to test the underline colour.
![DE39554-cf-after](https://user-images.githubusercontent.com/52468104/88434657-a1384d00-cdce-11ea-95de-16fb1643c9a3.gif)
