### PR TITLE
US114907 Set WebComponent lang type to ICU in the XML file

### DIFF
--- a/oslo/LangPackage.js
+++ b/oslo/LangPackage.js
@@ -45,7 +45,8 @@ class LangPackage {
 
 		serializer.writeTagBegin('package');
 		serializer.writeAttribute('name', this._name);
-		serializer.writeAttribute('type', 'Language'); // Could be IcuLanguage?
+		serializer.writeAttribute('type', 'Language');
+		serializer.writeAttribute('langtype', 'ICU');
 		serializer.writeAttribute('toolid', '0');
 		serializer.writeAttribute('version', '0.0.0.0');
 		serializer.writeTagBeginRightChar();


### PR DESCRIPTION
Added attribute for setting langtype for webcomponent lang xml, we can parse this in the LAIM tool to determine what to set the term type to.

The new XML:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<package name="WebComponents" type="Language" langtype="ICU" toolid="0" version="0.0.0.0">
  <collection name="d2l-activities\activityCard" type="Standard">
    <langTerm sortOrder="1" name="course">
      <defaultValue><![CDATA[Course]]></defaultValue>
      <description><![CDATA[]]></description>
    </langTerm>
    ...
```