### PR TITLE
DE39961 - [NYU Accessibility: 2.1] Navigation > Accessibility > Top-Level Navbar > Focus Indicator on link groups and course names causes text to shift up by 1px

### DIFF
--- a/sass/navigation/common.scss
+++ b/sass/navigation/common.scss
@@ -54,6 +54,7 @@ a.d2l-navigation-s-link:visited {
 
 .d2l-navigation-s a.d2l-navigation-s-link:hover,
 .d2l-navigation-s a.d2l-navigation-s-link:focus {
+	margin-top: 2px;
 	border-bottom: 2px solid;
 	outline: none;
 }

--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -104,6 +104,7 @@
 	}
 	&:hover .d2l-navigation-s-group-text,
 	&:focus .d2l-navigation-s-group-text {
+		margin-top: 2px;
 		border-bottom: 2px solid;
 	}
 }


### PR DESCRIPTION
### [DE39961 - certfix](https://rally1.rallydev.com/#/15545167705d/custom/21568985922?detail=%2Fdefect%2F408353296632&fdp=true)

This PR makes sure that the navigation links do not move when hovering over them (see gifs below).

**Before:**
![DE39961-before](https://user-images.githubusercontent.com/52468104/88940843-47b0a200-d256-11ea-85b1-430457ab3269.gif)

***

**After:**
![DE39961-after](https://user-images.githubusercontent.com/52468104/88941133-a7a74880-d256-11ea-98c1-1a209c4021c8.gif)
