### PR TITLE
(20.20.8) Set Awards leaderboard to version 1.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,8 +4484,8 @@
       }
     },
     "d2l-awards-leaderboard-ui": {
-      "version": "github:Brightspace/awards-leaderboard-ui#44a049d6465540d2cedd8f88757556cff1084506",
-      "from": "github:Brightspace/awards-leaderboard-ui#semver:^1",
+      "version": "github:Brightspace/awards-leaderboard-ui#6c70913bd3e31d03afbfe6d235f9fb39debd74d1",
+      "from": "github:Brightspace/awards-leaderboard-ui#semver:1.0.14",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/accordion": "^2",
@@ -4493,7 +4493,7 @@
         "@polymer/polymer": "^3",
         "@webcomponents/webcomponentsjs": "^2",
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-        "d2l-fetch-auth": "^1.2.0",
+        "d2l-fetch-auth": "^1.5.2",
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
         "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "d2l-activities": "BrightspaceHypermediaComponents/activities.git#semver:^3",
     "d2l-activity-alignments": "Brightspace/d2l-activity-alignments.git#semver:^2",
     "d2l-activity-exemptions": "Brightspace/d2l-activity-exemptions#semver:^2",
-    "d2l-awards-leaderboard-ui": "Brightspace/awards-leaderboard-ui#semver:^1",
+    "d2l-awards-leaderboard-ui": "github:Brightspace/awards-leaderboard-ui#semver:1.0.14",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^0.0",
     "d2l-content-store": "Brightspace/d2l-content-store#semver:^0",


### PR DESCRIPTION
* This will get Maya's fix to the width of leaderboard --Keeps correct core version
--Changes needed after updates to list component

![image](https://user-images.githubusercontent.com/17279735/88951769-6e75d500-d264-11ea-9c8a-cbeea9b3cce3.png)
