### PR TITLE
removing polymer behaviours expand-collapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^2",
     "d2l-outcomes-user-progress": "Brightspace/d2l-outcomes-user-progress.git#semver:^1",
-    "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-program-outcomes-picker": "Brightspace/program-outcomes-picker#semver:^3",
     "d2l-resize-aware": "BrightspaceUI/resize-aware.git#semver:^1",
     "d2l-rubric": "Brightspace/d2l-rubric#semver:^3",

--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -47,8 +47,6 @@ import '@brightspace-ui/core/components/menu/menu-item.js';
 // EditNavbar, MobileLinksArea, HomepageManageMenu, PageActionsMenu, Menu (MVC), ContextMenu (MVC),
 // MediaPlayer, contextMenu (legacy), ActionButtons (legacy)
 import '@brightspace-ui/core/components/menu/menu.js';
-// CollapsibleSection (MVC), Homepages
-import 'd2l-polymer-behaviors/d2l-dom-expand-collapse.js';
 
 window.D2L = window.D2L || {};
 


### PR DESCRIPTION
This saves 2 requests and 2138 bytes from every page.