### PR TITLE
Activities bump to release v3.53.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4288,7 +4288,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#6080df6523508c6c44f297410ece22e1e0b37293",
+      "version": "github:BrightspaceHypermediaComponents/activities#65fcfea8e272ac523a7fe28b6fb30467d66f60c7",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4288,7 +4288,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#65fcfea8e272ac523a7fe28b6fb30467d66f60c7",
+      "version": "github:BrightspaceHypermediaComponents/activities#4005fbdad08245baee0d26b9641ceef55ecdbe45",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
[DE39269](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F394449702920&fdp=true)
Hide the rubrics label if the user doesn't have permissions

[DE39958](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F408302156092&fdp=true)
Hide the RC Header if the user doesn't have manage delivery permission