### PR TITLE
bumped version of brightspace-ui/core to 1.72.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1209,9 +1209,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.72.6",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.72.6.tgz",
-      "integrity": "sha512-AhDsB8ZJ5hOP2VreCvDNFWkBBU0U92n7o3KiBD0BZlIj1shCm121j0DQPrQ5jJhiig+Z+dxapysos+tmWJUaIg==",
+      "version": "1.72.7",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.72.7.tgz",
+      "integrity": "sha512-ZV+ZtPrOoReYQjHze/BfSIu4D/iosDE670evuSKhpCficUaLw79odygCjUpMbwflWWDwvpThwCt3U2cNX46LSw==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
bumped version of `@brightspace-ui/core`