### PR TITLE
Fix missing d2l-status-indicator in the LMS

### DIFF
--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -40,6 +40,8 @@ import '@brightspace-ui/core/components/menu/menu-item.js';
 // EditNavbar, MobileLinksArea, HomepageManageMenu, PageActionsMenu, Menu (MVC), ContextMenu (MVC),
 // MediaPlayer, contextMenu (legacy), ActionButtons (legacy)
 import '@brightspace-ui/core/components/menu/menu.js';
+// StatusIndicator (both legacy and MVC)
+import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 
 window.D2L = window.D2L || {};
 


### PR DESCRIPTION
The LMS is using the `d2l-status-indicator` but we don't explicitly include it.  My guess was that it used to be included "for free" with something else in the bundle, and that got moved out.  We'll want to unbundle this and have the LMS load the module, but just trying to fix the problem for now - there's probably some cleanup that can happen in the LMS to get the legacy component using the MVC one.