### PR TITLE
20.20.9 - Fix missing d2l-status-indicator in the LMS

### DIFF
--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -40,6 +40,8 @@ import '@brightspace-ui/core/components/menu/menu-item.js';
 // EditNavbar, MobileLinksArea, HomepageManageMenu, PageActionsMenu, Menu (MVC), ContextMenu (MVC),
 // MediaPlayer, contextMenu (legacy), ActionButtons (legacy)
 import '@brightspace-ui/core/components/menu/menu.js';
+// StatusIndicator (both legacy and MVC)
+import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 
 window.D2L = window.D2L || {};
 


### PR DESCRIPTION
Cert version of https://github.com/Brightspace/brightspace-integration/pull/2423