### PR TITLE
version bump core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,9 +1218,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.74.4",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.74.4.tgz",
-      "integrity": "sha512-Lz3u447d2nps4fGrwlXxDmYNFkyx2EeIL+V8Q7AnoYILPGDVBXlsigGPSxAl1+2F+tNXORXlEOUdn5/b910ivg==",
+      "version": "1.75.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.75.2.tgz",
+      "integrity": "sha512-5U+NCUoY6KV7yPu21/Vm9589ctrQe/ugDGxTN3wVbxNuipeM0AMqIZfAIsBFR6TQDXK8RPyjR47xlAGiQX0/Cw==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
[US119539](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fuserstory%2F414155548564&fdp=true)

version bump to get [this](https://github.com/BrightspaceUI/core/pull/818) change to check the blobs dictionary for a request/response 

