### PR TITLE
exposing status-indicator as an individual asset

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -35,6 +35,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/menu/menu-item-radio.js',
 	'./node_modules/@brightspace-ui/core/components/menu/menu-item-separator.js',
 	'./node_modules/@brightspace-ui/core/components/more-less/more-less.js',
+	'./node_modules/@brightspace-ui/core/components/status-indicator/status-indicator.js',
 	'./node_modules/@brightspace-ui/core/components/switch/switch.js',
 	'./node_modules/@brightspace-ui/core/components/switch/switch-visibility.js',
 	'./node_modules/@brightspace-ui/core/components/tooltip/tooltip.js',


### PR DESCRIPTION
Step one to unbundling status-indicator is to ensure there's a dedicated asset for it that we can load.