### PR TITLE
Update leaderboard version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4558,7 +4558,7 @@
       }
     },
     "d2l-awards-leaderboard-ui": {
-      "version": "github:Brightspace/awards-leaderboard-ui#182158406ad37d0d4bde92df02c9d9bcd27044e7",
+      "version": "github:Brightspace/awards-leaderboard-ui#c44190a2cd542f3721b7563a406357fa23e6a87b",
       "from": "github:Brightspace/awards-leaderboard-ui#semver:^1",
       "dev": true,
       "requires": {
@@ -4566,8 +4566,6 @@
         "@brightspace-ui/core": "^1",
         "@polymer/polymer": "^3",
         "@webcomponents/webcomponentsjs": "^2",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-        "d2l-fetch-auth": "^1.5.2",
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
         "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",


### PR DESCRIPTION
This is a fix for DE40387. 

We have a new version of leaderboard that drops the unneeded leftover FRA auth bits