### PR TITLE
Kapatel/usa/us119539 version bump oslo 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4497,7 +4497,8 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#432321ae2a1a7ea806666d4f9e5571dcc46e25d2",      "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
+      "version": "github:BrightspaceHypermediaComponents/activities#432321ae2a1a7ea806666d4f9e5571dcc46e25d2",
+      "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4497,7 +4497,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#df2c99b74bd310e3d3471004c9f1e9f906463951",
+      "version": "github:BrightspaceHypermediaComponents/activities#8933a4fc6581fac3c6e58dc2069e9cb62f26bfe7 ",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4497,7 +4497,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#0de4149b1bf7591e59f09017166b49b3cebb004b",
+      "version": "github:BrightspaceHypermediaComponents/activities#df2c99b74bd310e3d3471004c9f1e9f906463951",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {
@@ -4505,7 +4505,7 @@
         "@brightspace-ui-labs/accordion": "^2.0.2",
         "@brightspace-ui-labs/edit-in-place": "^1.0.11",
         "@brightspace-ui-labs/list-item-accumulator": "^1",
-        "@brightspace-ui/core": "^1.65.0",
+        "@brightspace-ui/core": "^1.75.2",
         "@brightspace-ui/intl": "^3.0.1",
         "@d2l/d2l-attachment": "github:Brightspace/attachment#semver:^1",
         "@polymer/iron-resizable-behavior": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4497,7 +4497,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#8933a4fc6581fac3c6e58dc2069e9cb62f26bfe7 ",
+      "version": "github:BrightspaceHypermediaComponents/activities#df2c99b74bd310e3d3471004c9f1e9f906463951 ",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
[US119539](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fuserstory%2F414155548564&fdp=true)

Version bump to v3.53.42

version bump to get [this](https://github.com/BrightspaceHypermediaComponents/activities/pull/1090) core version update in activities 