### PR TITLE
[20.20.10] Bump activities to include CERT fixes - DE40524, DE40501

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4509,7 +4509,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#1486f3492148ecabba65a30cbaf4cce9b40a9f46",
+      "version": "github:BrightspaceHypermediaComponents/activities#91b26db563662ef86ca55a7ffcc99d50df02e546",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
DE40524 FACE activities Assignment type not properly disabled
DE40501 due date always empty on first load