### PR TITLE
DE40414 Updating rubrics commit hash again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5241,7 +5241,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#a2c53342d8b7d06f3a444581aac2c81d6fb09f45",
+      "version": "github:Brightspace/d2l-rubric#c90f147c60670b36d4a9bbc1dc642de92dc32751",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Updating the rubrics commit hash for the package lock again, now with a github version bumped so we won't have to roll back.
* [New version created here](https://github.com/Brightspace/d2l-rubric/releases/tag/v3.7.32)
* [Original pr found here](https://github.com/Brightspace/brightspace-integration/pull/2457)
* [Revert due to github version missing here](https://github.com/Brightspace/brightspace-integration/pull/2476#discussion_r488695927)