### PR TITLE
bump sequences version to prevent JS error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5313,7 +5313,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#2638e8341dcb13688a157c0a8dcf9c1799fe480a",
+      "version": "github:BrightspaceHypermediaComponents/sequences#a728fbb7bfe2e1eceb102cf14d1024147ab95eb4",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Updating BSI with latest version of sequences. Update includes a fix to prevent a JS error when viewing HTML topics in LX.