### PR TITLE
Update oslo readme

### DIFF
--- a/oslo/README.md
+++ b/oslo/README.md
@@ -17,6 +17,8 @@ Produces LMS definition/translation XMLs and an Oslo manifest file for the Serge
 configuration files specified in ".serge-mapping.json". Should be run every
 build, as output is synced to the monolith with the BSI version bump.
 
+Note: The LMS `LANG_OBJECTS` table is not able to store certain special characters like `@`. It will do a conversion to a unicode representation like `\u0040`. For this reason if there is a special character in the package/collection/term name support needs to be added to the OSLO controller in the LMS to parse that character.
+
 **Output:**
 
 	build/

--- a/oslo/README.md
+++ b/oslo/README.md
@@ -1,11 +1,9 @@
-Off-Stack Langerm Overridest (OSLO)
-===================================
+# Off-Stack Langerm Overridest (OSLO)
 
 The enclosed scripts build the integration files needed to support overriding
 web component langterms in the LMS.
 
-generate-serge-mapping
-----------------------
+## generate-serge-mapping
 
 Enumerates the node_modules dependencies looking for Serge configuration files.
 Produces a mapping (".serge-mapping.json" in the repository root) of dependency
@@ -13,14 +11,13 @@ name to Serge config file.
 
 Should be run when new components are added to BSI.
 
-generate-monolith-xml
----------------------
+## generate-monolith-xml
 
 Produces LMS definition/translation XMLs and an Oslo manifest file for the Serge
 configuration files specified in ".serge-mapping.json". Should be run every
 build, as output is synced to the monolith with the BSI version bump.
 
-Output:
+**Output:**
 
 	build/
 		langterms/

--- a/oslo/README.md
+++ b/oslo/README.md
@@ -1,4 +1,4 @@
-# Off-Stack Langerm Overridest (OSLO)
+# Off-Stack Langerm Overrides (OSLO)
 
 The enclosed scripts build the integration files needed to support overriding
 web component langterms in the LMS.


### PR DESCRIPTION
Updating the docs to use markdown and to mention the issue with the special characters. I want to link to them from the OSLO controller so people have more context on why we are going to parse `@` when retrieving from the DB in the code I added (in a different PR in the lms).

To view the markdown: https://github.com/Brightspace/brightspace-integration/blob/ushamim/usa/update-oslo-readme/oslo/README.md