### PR TITLE
Add class for disabling scroll on the page

### DIFF
--- a/sass/page.scss
+++ b/sass/page.scss
@@ -77,3 +77,7 @@ body.d2l-body-unresolved {
 	position: fixed;
 	top: 10px;
 }
+
+.d2l-disable-overflow {
+	overflow-y: unset;
+}


### PR DESCRIPTION
When using LX, design has decided that we don't want to have "disabled" scroll bars on the side of the page. However, when using d2l-body, which we need to do for other behavior and style reasons, `overflow-y: scroll` is added. This pr just adds another class which we can append in our controller when creating LX to unset that property.

Followup pr to that controller will come later once/if this gets merged.

![scroll](https://user-images.githubusercontent.com/14796305/93530227-d363b800-f902-11ea-95c0-90b26a9da672.gif)
