### PR TITLE
Remove -s from the git diff command

### DIFF
--- a/.github/workflows/bsi-update.yml
+++ b/.github/workflows/bsi-update.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Check For Changes
         id: check-changes
-        run: echo "::set-output name=changes-exist::$(git diff -s --exit-code package-lock.json && echo false || echo true)"
+        run: echo "::set-output name=changes-exist::$(git diff --exit-code package-lock.json && echo false || echo true)"
 
       - name: Create Commit
         if: steps.check-changes.outputs.changes-exist

--- a/.github/workflows/bsi-update.yml
+++ b/.github/workflows/bsi-update.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Check For Changes
         id: check-changes
-        run: echo "::set-output name=changes-exist::$(git diff --exit-code package-lock.json && echo false || echo true)"
+        run: git diff --exit-code package-lock.json || echo "::set-output name=changes-exist::true"
 
       - name: Create Commit
         if: steps.check-changes.outputs.changes-exist


### PR DESCRIPTION
It seems to think there is a diff every time even when nothing has changed since the last run on that branch, so I want to see what it sees.  I think this will be helpful for any future debugging, so probably going to keep it this way!