### PR TITLE
US121057 OSLO > Fail BSI build when there are invalid term names

### DIFF
--- a/oslo/Serge.js
+++ b/oslo/Serge.js
@@ -20,6 +20,8 @@ const ParseJsNameRegExp = /["']/g;
 const ParseJsEscapeRegExp = /\\(['"])/g;
 const ParseJsEscapeReplacer = (_, ch) => ch;
 
+let InvalidTermFound = false;
+
 class Rewrite {
 
 	constructor(rewrite) {
@@ -182,8 +184,18 @@ class Serge {
 
 		for (const [name, defaultValue] of entries) {
 
-			const object = new LangObject(name, defaultValue, EmptyString);
-			collection.addObject(object);
+			const validName = Util.validLangObjectName(name, this._name);
+
+			if (validName) {
+				const object = new LangObject(name, defaultValue, EmptyString);
+				collection.addObject(object);
+			} else {
+				InvalidTermFound = true;
+			}
+		}
+
+		if (InvalidTermFound) {
+			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 
 		return collection;
@@ -202,8 +214,18 @@ class Serge {
 				translation: defaultValue
 			}] = entry;
 
-			const object = new LangObject(name, defaultValue, description);
-			collection.addObject(object);
+			const validName = Util.validLangObjectName(name, this._name);
+
+			if(validName) {
+				const object = new LangObject(name, defaultValue, description);
+				collection.addObject(object);
+			} else {
+				InvalidTermFound = true;
+			}
+		}
+
+		if (InvalidTermFound) {
+			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 
 		return collection;
@@ -226,8 +248,18 @@ class Serge {
 				ParseJsEscapeReplacer
 			);
 
-			const object = new LangObject(name, defaultValue, description);
-			collection.addObject(object);
+			const validName = Util.validLangObjectName(name, this._name);
+
+			if (validName) {
+				const object = new LangObject(name, defaultValue, description);
+				collection.addObject(object);
+			} else {
+				InvalidTermFound = true;
+			}
+		}
+
+		if (InvalidTermFound) {
+			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 
 		return collection;

--- a/oslo/Serge.js
+++ b/oslo/Serge.js
@@ -179,7 +179,7 @@ class Serge {
 		const source = JSON.parse(text);
 		const entries = Object.entries(source);
 		const collection = new LangCollection(this._name);
-		let InvalidTermFound = false;
+		let invalidTermFound = false;
 
 		for (const [name, defaultValue] of entries) {
 
@@ -189,11 +189,11 @@ class Serge {
 				const object = new LangObject(name, defaultValue, EmptyString);
 				collection.addObject(object);
 			} else {
-				InvalidTermFound = true;
+				invalidTermFound = true;
 			}
 		}
 
-		if (InvalidTermFound) {
+		if (invalidTermFound) {
 			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 
@@ -205,7 +205,7 @@ class Serge {
 		const source = JSON.parse(text);
 		const entries = Object.entries(source);
 		const collection = new LangCollection(this._name);
-		let InvalidTermFound = false;
+		let invalidTermFound = false;
 
 		for (const entry of entries) {
 
@@ -220,11 +220,11 @@ class Serge {
 				const object = new LangObject(name, defaultValue, description);
 				collection.addObject(object);
 			} else {
-				InvalidTermFound = true;
+				invalidTermFound = true;
 			}
 		}
 
-		if (InvalidTermFound) {
+		if (invalidTermFound) {
 			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 
@@ -235,7 +235,7 @@ class Serge {
 
 		const matches = text.matchAll(ParseJsRegExp);
 		const collection = new LangCollection(this._name);
-		let InvalidTermFound = false;
+		let invalidTermFound = false;
 
 		for (const match of matches) {
 
@@ -255,11 +255,11 @@ class Serge {
 				const object = new LangObject(name, defaultValue, description);
 				collection.addObject(object);
 			} else {
-				InvalidTermFound = true;
+				invalidTermFound = true;
 			}
 		}
 
-		if (InvalidTermFound) {
+		if (invalidTermFound) {
 			throw 'OSLO error: Forbidden characters used in LangObject name';
 		}
 

--- a/oslo/Serge.js
+++ b/oslo/Serge.js
@@ -216,7 +216,7 @@ class Serge {
 
 			const validName = Util.validLangObjectName(name, this._name);
 
-			if(validName) {
+			if (validName) {
 				const object = new LangObject(name, defaultValue, description);
 				collection.addObject(object);
 			} else {

--- a/oslo/Serge.js
+++ b/oslo/Serge.js
@@ -20,8 +20,6 @@ const ParseJsNameRegExp = /["']/g;
 const ParseJsEscapeRegExp = /\\(['"])/g;
 const ParseJsEscapeReplacer = (_, ch) => ch;
 
-let InvalidTermFound = false;
-
 class Rewrite {
 
 	constructor(rewrite) {
@@ -181,6 +179,7 @@ class Serge {
 		const source = JSON.parse(text);
 		const entries = Object.entries(source);
 		const collection = new LangCollection(this._name);
+		let InvalidTermFound = false;
 
 		for (const [name, defaultValue] of entries) {
 
@@ -206,6 +205,7 @@ class Serge {
 		const source = JSON.parse(text);
 		const entries = Object.entries(source);
 		const collection = new LangCollection(this._name);
+		let InvalidTermFound = false;
 
 		for (const entry of entries) {
 
@@ -235,6 +235,7 @@ class Serge {
 
 		const matches = text.matchAll(ParseJsRegExp);
 		const collection = new LangCollection(this._name);
+		let InvalidTermFound = false;
 
 		for (const match of matches) {
 

--- a/oslo/Util.js
+++ b/oslo/Util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ForbiddenCharacterAllowedList = ['d2l-activities\\activityEditor'];
+const ForbiddenCharacters = ['.'];
 const EscapeRegExp = /([^a-zA-Z0-9\\:_-])/g;
 const EscapeMap = new Map();
 const EscapeReplacer = (_, ch) => {
@@ -41,8 +43,20 @@ function backSlash(value) {
 	return value.replace(ForwardSlashRegExp, BackSlashChar);
 }
 
+function validLangObjectName(objectName, collectionName) {
+	const nameContainsForbiddenCharacter = ForbiddenCharacters.some(char => objectName.includes(char));
+
+	if (nameContainsForbiddenCharacter && !ForbiddenCharacterAllowedList.includes(collectionName)) {
+		console.error(`OSLO error: LangObject name "${objectName}" in collection "${collectionName}" cannot contain forbidden characters`);
+		return false;
+	}
+
+	return true;
+}
+
 exports.byFirstArrayItem = byFirstArrayItem;
 exports.escapeObjectName = escapeObjectName;
 exports.forwardSlash = forwardSlash;
 exports.backSlash = backSlash;
 exports.ForwardSlashChar = ForwardSlashChar;
+exports.validLangObjectName = validLangObjectName;

--- a/oslo/Util.js
+++ b/oslo/Util.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const ForbiddenCharacterAllowedList = ['d2l-activities\\activityEditor'];
+const ForbiddenCharacterAllowedList = [
+	'd2l-activities\\activityEditor',
+	'@d2l\\d2l-attachment\\d2l-attachment'
+];
 const ForbiddenCharacters = ['.'];
 const EscapeRegExp = /([^a-zA-Z0-9\\:_-])/g;
 const EscapeMap = new Map();


### PR DESCRIPTION
This implements [US121057](https://rally1.rallydev.com/#/388869855380d/dashboard?detail=%2Fuserstory%2F439112983600&fdp=true) and causes the BSI build to fail if there are any characters in a term name that contain a forbidden character (for now that is only `.` but we may add more later).