### PR TITLE
Add Discover as new BSI dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4870,23 +4870,23 @@
       }
     },
     "d2l-discovery-fra": {
-      "version": "github:Brightspace/discovery-fra#7ccab0c1ccc14c3ecb4cd48a1ef0427c90227240",
+      "version": "github:Brightspace/discovery-fra#c260fac18aa89f92db5fa02b258aae3d618835c3",
       "from": "github:Brightspace/discovery-fra#semver:^3",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/pagination": "0.0.8",
-        "@brightspace-ui/core": "^1.83.1",
+        "@brightspace-ui/core": "^1",
         "@polymer/app-route": "^3.0.0-pre.15",
         "@polymer/iron-pages": "^3.0.0-pre.15",
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/paper-dialog": "^3.0.1",
-        "@polymer/polymer": "3.1.0",
+        "@polymer/polymer": "^3",
         "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",
         "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-        "d2l-fetch-auth": "github:Brightspace/d2l-fetch-auth",
+        "d2l-fetch-auth": "^1",
         "d2l-fetch-dedupe": "^1.3.0",
-        "d2l-hypermedia-constants": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
+        "d2l-hypermedia-constants": "^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
         "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
@@ -4899,30 +4899,6 @@
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
         "url-polyfill": "^1.1.10",
         "whatwg-fetch": "^3.4.1"
-      },
-      "dependencies": {
-        "@polymer/polymer": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.1.0.tgz",
-          "integrity": "sha512-hwN8IMERsFATz/9dSMxYHL+84J9uBkPuuarxJWlTsppZ4CAYTZKnepBfNrKoyNsafBmA3yXBiiKPPf+fJtza7A==",
-          "dev": true,
-          "requires": {
-            "@webcomponents/shadycss": "^1.5.2"
-          }
-        },
-        "d2l-fetch-auth": {
-          "version": "github:Brightspace/d2l-fetch-auth#b499987373084cebbe42d82799a2e49f01a7b4e1",
-          "from": "github:Brightspace/d2l-fetch-auth",
-          "dev": true,
-          "requires": {
-            "frau-jwt": "^2.0.3"
-          }
-        },
-        "d2l-hypermedia-constants": {
-          "version": "github:Brightspace/d2l-hypermedia-constants#8009c0b05a4df37794b898069953e339b827e1ce",
-          "from": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
-          "dev": true
-        }
       }
     },
     "d2l-dnd-sortable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2178,6 +2178,29 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/paper-dialog": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog/-/paper-dialog-3.0.1.tgz",
+      "integrity": "sha512-KvglYbEq7AWJvui2j6WKLnOvgVMeGjovAydGrPRj7kVzCiD49Eq/hpYFJTRV5iDcalWH+mORUpw+jrFnG9+Kgw==",
+      "dev": true,
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dialog-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-behavior/-/paper-dialog-behavior-3.0.1.tgz",
+      "integrity": "sha512-wbI4kCK8le/9MHT+IXzvHjoatxf3kd3Yn0tgozAiAwfSZ7N4Ubpi5MHrK0m9S9PeIxKokAgBYdTUrezSE5378A==",
+      "dev": true,
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/paper-icon-button": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/paper-icon-button/-/paper-icon-button-3.0.2.tgz",
@@ -4846,6 +4869,62 @@
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
+    "d2l-discovery-fra": {
+      "version": "github:Brightspace/discovery-fra#7ccab0c1ccc14c3ecb4cd48a1ef0427c90227240",
+      "from": "github:Brightspace/discovery-fra#semver:^3",
+      "dev": true,
+      "requires": {
+        "@brightspace-ui-labs/pagination": "0.0.8",
+        "@brightspace-ui/core": "^1.83.1",
+        "@polymer/app-route": "^3.0.0-pre.15",
+        "@polymer/iron-pages": "^3.0.0-pre.15",
+        "@polymer/iron-resizable-behavior": "^3.0.0",
+        "@polymer/paper-dialog": "^3.0.1",
+        "@polymer/polymer": "3.1.0",
+        "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",
+        "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "d2l-fetch-auth": "github:Brightspace/d2l-fetch-auth",
+        "d2l-fetch-dedupe": "^1.3.0",
+        "d2l-hypermedia-constants": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
+        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "dompurify": "^2.0.7",
+        "fastdom": "^1.0.8",
+        "promise-polyfill": "8.1.0",
+        "siren-parser": "^8.2.0",
+        "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
+        "url-polyfill": "^1.1.10",
+        "whatwg-fetch": "^3.4.1"
+      },
+      "dependencies": {
+        "@polymer/polymer": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.1.0.tgz",
+          "integrity": "sha512-hwN8IMERsFATz/9dSMxYHL+84J9uBkPuuarxJWlTsppZ4CAYTZKnepBfNrKoyNsafBmA3yXBiiKPPf+fJtza7A==",
+          "dev": true,
+          "requires": {
+            "@webcomponents/shadycss": "^1.5.2"
+          }
+        },
+        "d2l-fetch-auth": {
+          "version": "github:Brightspace/d2l-fetch-auth#b499987373084cebbe42d82799a2e49f01a7b4e1",
+          "from": "github:Brightspace/d2l-fetch-auth",
+          "dev": true,
+          "requires": {
+            "frau-jwt": "^2.0.3"
+          }
+        },
+        "d2l-hypermedia-constants": {
+          "version": "github:Brightspace/d2l-hypermedia-constants#8009c0b05a4df37794b898069953e339b827e1ce",
+          "from": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
+          "dev": true
+        }
+      }
+    },
     "d2l-dnd-sortable": {
       "version": "github:Brightspace/dnd-sortable#f2682f9fa8b35deaee603a72a332687ca80ae83e",
       "from": "github:Brightspace/dnd-sortable#semver:^3",
@@ -5808,6 +5887,12 @@
       "requires": {
         "domelementtype": "^2.0.1"
       }
+    },
+    "dompurify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
+      "integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg==",
+      "dev": true
     },
     "domutils": {
       "version": "2.4.2",
@@ -24833,6 +24918,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
+      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA==",
+      "dev": true
+    },
     "promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -27076,6 +27167,12 @@
           "dev": true
         }
       }
+    },
+    "url-polyfill": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.10.tgz",
+      "integrity": "sha512-vSaPpaRgBrf41+Uky1myiSh6gpcbw8FpwHYnEy0abxndojOBnIs+yh/49gKYFLtUMP9qoNWjn6j9aUVy23Ie2A==",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
     "d2l-content-store": "Brightspace/d2l-content-store#semver:^0",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^1",
+    "d2l-discovery-fra": "github:Brightspace/discovery-fra#semver:^3",
     "d2l-engagement-dashboard": "Brightspace/insights-engagement-dashboard#semver:^0.1",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-fetch-auth": "^1",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -81,6 +81,7 @@ const appFiles = [
 	'./web-components/d2l-activity-exemptions.js',
 	'./web-components/d2l-awards-leaderboard-ui.js',
 	'./web-components/d2l-cpd-report.js',
+	'./web-components/d2l-discovery-app.js',
 	'./web-components/d2l-enrollment-collection-widget.js',
 	'./web-components/d2l-enrollment-summary-view.js',
 	'./web-components/d2l-image-banner-overlay.js',

--- a/web-components/d2l-discovery-app.js
+++ b/web-components/d2l-discovery-app.js
@@ -1,0 +1,1 @@
+import 'd2l-discovery-fra/src/discovery-app.js';


### PR DESCRIPTION
Discover-FRA is being migrated into working as a BSI component. 
Therefore it'll need to be in BSI!

All old and unnecessary dependencies were removed from discover before this PR. The remaining paper dialog and dompurify will be much more easily removed post-migration.