### PR TITLE
Bump `d2l-outcomes-level-of-achievement` to Major Version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4561,7 +4561,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#1ed32931e41eb2de7606815a0933583c376f1432",
+      "version": "github:Brightspace/d2l-activity-alignments#077c5bce60e701c7262f534ba39c5cb5c1586e78",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "dev": true,
       "requires": {
@@ -4579,7 +4579,7 @@
         "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
-        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^2",
+        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
@@ -4721,7 +4721,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#a459857a729e855d4f64215f08618ef3f3965c84",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#0c5755ef2abfb57bb6729a665698c8057b7e1800",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
       "dev": true,
       "requires": {
@@ -4733,7 +4733,7 @@
         "d2l-activity-alignments": "github:Brightspace/d2l-activity-alignments#semver:^2",
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-hypermedia-constants": "^6.36.0",
-        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^2",
+        "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
         "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
         "d2l-rubric": "github:Brightspace/d2l-rubric#semver:^3",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
@@ -5237,8 +5237,8 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#db592a4db02f163276af9857c7b3eb9eb23bdc50",
-      "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^2",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#f850f4d12b088a27560bc45beecb6fc45de50b58",
+      "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1.41.0",
@@ -5249,7 +5249,7 @@
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-        "fastdom": "^1.0.8"
+        "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
     "d2l-outcomes-overall-achievement": {
@@ -26825,9 +26825,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==",
       "dev": true
     },
     "tsscmp": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
-    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^2",
+    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^3",
     "d2l-outcomes-user-progress": "Brightspace/d2l-outcomes-user-progress.git#semver:^1",
     "d2l-program-outcomes-picker": "Brightspace/program-outcomes-picker#semver:^3",
     "d2l-resize-aware": "BrightspaceUI/resize-aware.git#semver:^1",


### PR DESCRIPTION
Bump `d2l-outcomes-level-of-achievement` to Major Version 3
BSI components that depend on this component:
* `d2l-consistent-evaluation`
* `d2l-activity-alignments`