### PR TITLE
unbundling dropdown-more component

### DIFF
--- a/web-components/bsi-unbundled.js
+++ b/web-components/bsi-unbundled.js
@@ -17,8 +17,6 @@ import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 // ContextMenu (MVC), PageActions, EditNavbar, NavbarItem, ContextMenu (legacy), ActionButtonMenu (legacy)
 // ButtonMenu (MVC), MediaPlayer
 import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
-// EditNavbar, Homepages
-import '@brightspace-ui/core/components/dropdown/dropdown-more.js';
 // ContextMenuPlaceholder, PageActionsMenu, Navigation, MenuFlyout, MenuFlyoutCustom, ButtonMenu,
 // ContextMenu placeholder (legacy), LayoutBuilder
 import '@brightspace-ui/core/components/dropdown/dropdown.js';


### PR DESCRIPTION
All references in the LMS are now going through the MVC control.