### PR TITLE
Fix navigation group focus

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -16,6 +16,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/button/button-subtle.js',
 	'./node_modules/@brightspace-ui/core/components/button/floating-buttons.js',
 	'./node_modules/@brightspace-ui/core/components/dialog/dialog-fullscreen.js',
+	'./node_modules/@brightspace-ui/core/components/dropdown/dropdown.js',
 	'./node_modules/@brightspace-ui/core/components/dropdown/dropdown-button.js',
 	'./node_modules/@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js',
 	'./node_modules/@brightspace-ui/core/components/dropdown/dropdown-content.js',

--- a/sass/navigation/main.scss
+++ b/sass/navigation/main.scss
@@ -101,6 +101,7 @@
 	&:hover .d2l-navigation-s-group-wrapper d2l-icon,
 	&:focus .d2l-navigation-s-group-wrapper d2l-icon {
 		cursor: pointer;
+		outline: none;
 	}
 	&:hover .d2l-navigation-s-group-text,
 	&:focus .d2l-navigation-s-group-text {


### PR DESCRIPTION
Noticed that only on legacy pages that navigation groups get an outline when focused:

![Screen Shot 2020-10-07 at 3 47 46 PM](https://user-images.githubusercontent.com/5491151/95381073-a24d2680-08b5-11eb-9158-df22fa8d1384.png)

MVC pages aren't impacted because the `reset.css` stylesheet removes all outlines. Not sure when this was introduced... it may have also been a recent Chrome change. 🤷 