### PR TITLE
US121650 - Add auto merge GitHub action

### DIFF
--- a/.github/workflows/bsi-update-merge.yml
+++ b/.github/workflows/bsi-update-merge.yml
@@ -1,0 +1,30 @@
+# This workflow will check for any BSI auto-update PRs and merge them
+# It will only merge them if they are approved and CI has passed
+name: BSI Update Merge
+
+on:
+  workflow_dispatch: # manual trigger
+
+jobs:
+  build:
+    # self-hosted doesn't work for public repos (security), so need to use ubuntu
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    env:
+      BRANCH_NAME: ghworkflow/bsi_auto_update
+
+    steps:
+      - name: Merge Auto Update PRs
+        uses: Brightspace/third-party-actions@pascalgn/automerge-action
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # The labels that need to be present for a pull request to be merged
+          MERGE_LABELS: "auto-merge"
+          # The labels to automatically remove from a pull request once it has been merged
+          MERGE_REMOVE_LABELS: "auto-merge"
+          # Possible values are merge, rebase, and squash
+          MERGE_METHOD: "merge"
+          # Disabling retries - if CI isn't done, we will try again in ten minutes
+          MERGE_RETRIES: "0"

--- a/.github/workflows/bsi-update.yml
+++ b/.github/workflows/bsi-update.yml
@@ -78,7 +78,7 @@ jobs:
                 owner: 'Brightspace',
                 repo: 'brightspace-integration',
                 issue_number: createPrResult.data.number,
-                labels: ['auto-update']
+                labels: ['auto-update', 'auto-merge']
               });
               console.log('Created new PR')
               return createPrResult.data.number;

--- a/cli/autotag.js
+++ b/cli/autotag.js
@@ -77,11 +77,11 @@ async function tryGetActiveDevelopmentRelease() {
 	if (releases.TotalResultCount === 2) {
 		const releaseDate = moment.utc(releases.Results[0].ReleaseDate).tz('America/Toronto');
 		if (releaseDate.year() === nowEst.year() && releaseDate.month() === nowEst.month() && releaseDate.date() === nowEst.date()) {
-			if (nowEst.hour() >= 12) {
-				console.log('Last day of release and after noon EST (branch time), using next release.');
+			if (nowEst.hour() >= 10) {
+				console.log('Last day of release and after 10am EST (approximate last build before branching), using next release.');
 				release = releases.Results[1];
 			} else {
-				console.log('Last day of release and before noon EST (branch time), using current release.');
+				console.log('Last day of release and before 10am EST (approximate last build before branching), using current release.');
 			}
 		}
 	}


### PR DESCRIPTION
Adding the auto-merge action before the auto-approve to make it easier to test.  This is based on the one the LMS uses to auto-merge BSI PRs there.