### PR TITLE
US121650 - Remove schedule for now

### DIFF
--- a/.github/workflows/bsi-update-merge.yml
+++ b/.github/workflows/bsi-update-merge.yml
@@ -3,9 +3,6 @@
 name: BSI Update Merge
 
 on:
-  schedule:
-  - cron: "*/10 12-23 * * 1-5" # Every 10 minutes. Mon-Fri 8AM-759PM EDT. 7AM-659PM EST.
-  - cron: "*/10 0-1 * * 2-6" # Every 10 minutes. Mon-Fri 8PM-959PM EDT. 7PM-859PM EST.
   workflow_dispatch: # manual trigger
 
 jobs:


### PR DESCRIPTION
The schedule did seem to fix it, I am getting the full list of PRs now and console logs about what it does with each one.  Removing for now to be sure and because I have to run and don't want it running every ten minutes without more testing.