### PR TITLE
upgrading to core version 1.85.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,9 +1239,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.85.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.85.2.tgz",
-      "integrity": "sha512-64Sx4tSXIUaE9KZ9k4V+H7JBUolBR6LnBK1M90BXQ7LrWVRxDYAgYTB3qqvZUKmUzM6KYxCThyB4XqOKVsJA8g==",
+      "version": "1.85.3",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.85.3.tgz",
+      "integrity": "sha512-P51qJNZM7fKTZOzxEbFz/tAYUGBFwp87rdF8Kbwyf7GVAh/uNjklOukh/8EXbTWVYrGK9rvANxY6K1H6M/b/3A==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Picks up the changes to card that prevents a `null` `href` from being a link.