### PR TITLE
fixing UMD time bomb in focus-visible polyfill

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -151,7 +151,7 @@ export default merge(config, {
 		}),
 		replace({
 			define: 'defineNoYouDont', /* prevents UMD time bomb as fastdom will try to call define() on UMD FRA pages */
-			include: 'node_modules/fastdom/fastdom.js'
+			include: ['node_modules/fastdom/fastdom.js', 'node_modules/focus-visible/dist/focus-visible.js']
 		})
 	]
 });


### PR DESCRIPTION
Still waiting for my local instance to build so I can actually test this, but wanted to get the PR up so it's ready to go.

This is the same fix we use for `fastdom`, where we just hackily replace the word `define` in the library with `defineNoYouDont` -- good times.