### PR TITLE
Bump d2l-outcomes-level-of-achievements back to Major Version 2 (20.20.10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5232,7 +5232,7 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#73aed188c88e30af58e4f6908f538991ad2c8102",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#db592a4db02f163276af9857c7b3eb9eb23bdc50",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^2",
       "dev": true,
       "requires": {


### PR DESCRIPTION
In the 20.20.10 release, the commit hash of `d2l-outcomes-level-of-achievements` in `package-lock.json` points to a buggy version of Major Version 3, even though the major version of the component in `package.json` is 2.

Changes:
* Bump the commit hash of `d2l-outcomes-level-of-achievements` back to the latest commit hash in Major Version 2 (prior to LitElement conversion)

https://rally1.rallydev.com/#/detail/defect/445117376000?fdp=true
