### PR TITLE
manually bump consistent-eval to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4832,8 +4832,8 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#cde83f14a587e3f9ef82013dd2051fcbb8de444c",
-      "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#93b7741351ccc105f0e1255f4c3c50d2dcf68a3b",
+      "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/grade-result": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "d2l-awards-leaderboard-ui": "Brightspace/awards-leaderboard-ui#semver:^1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-capture-central": "Brightspace/capture-central#semver:^0",
-    "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^0",
+    "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
     "d2l-content-store": "Brightspace/d2l-content-store#semver:^0",
     "d2l-content-store-add-content": "Brightspace/content-store-add-content#semver:^0",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^1",


### PR DESCRIPTION
We want `master` of BSI to have the latest CE version as well