### PR TITLE
Bump repos for locked COA (20.20.12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4905,7 +4905,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#93b7741351ccc105f0e1255f4c3c50d2dcf68a3b",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#cd38e3b9670aaa72e4bceeeef556dd0038ed9a3b",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "dev": true,
       "requires": {
@@ -5442,7 +5442,7 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#e85184a28a95a3c156fb39a5f403d3d212f38ac0",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#3d27c11c95fe15dedc44c91f6fea42bc56d22be1",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "dev": true,
       "requires": {
@@ -5456,7 +5456,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#f575d167c534731046b52d278a0bde6988785175",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#612182b261a2244bdc8b5dd1017c2ac68585ea54",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Cert bumps for the following changes:
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/181
https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/64
https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/59

* Bump `d2l-consistent-evaluation` to v1.0.4
* Bump `d2l-outcomes-overall-achievement` to v1.1.30
* Bump `d2l-outcomes-level-of-achievement` to v3.0.13