### PR TITLE
Updated Discover version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,6 +1140,20 @@
         "lit-element": "^2.2.1"
       }
     },
+    "@brightspace-ui-labs/facet-filter-sort": {
+      "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
+      "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
+      "dev": true,
+      "requires": {
+        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "lit-element": "^2"
+      }
+    },
     "@brightspace-ui-labs/file-uploader": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/file-uploader/-/file-uploader-2.0.1.tgz",
@@ -4914,12 +4928,13 @@
       }
     },
     "d2l-discovery-fra": {
-      "version": "github:Brightspace/discovery-fra#131e17693cc3a63cd4b2db0ba2a9695d8d0f6fbe",
-      "from": "github:Brightspace/discovery-fra#bsi-temp-fix",
+      "version": "github:Brightspace/discovery-fra#587caac9d886bf3187afdc8522bdf84747da2a45",
+      "from": "github:Brightspace/discovery-fra#semver:^3",
       "dev": true,
       "requires": {
+        "@brightspace-ui-labs/facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "@brightspace-ui-labs/pagination": "^1",
-        "@brightspace-ui/core": "^1",
+        "@brightspace-ui/core": "^1.102.5",
         "@polymer/app-route": "^3.0.0-pre.15",
         "@polymer/iron-pages": "^3.0.0-pre.15",
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -4936,13 +4951,13 @@
         "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
         "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-        "dompurify": "^2.0.7",
+        "dompurify": "^2.2.2",
         "fastdom": "^1.0.8",
         "promise-polyfill": "8.1.0",
         "siren-parser": "^8.2.0",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
-        "url-polyfill": "^1.1.10",
-        "whatwg-fetch": "^3.4.1"
+        "url-polyfill": "^1.1.12",
+        "whatwg-fetch": "^3.5.0"
       }
     },
     "d2l-dnd-sortable": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "d2l-content-store": "Brightspace/d2l-content-store#semver:^0",
     "d2l-content-store-add-content": "Brightspace/content-store-add-content#semver:^0",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^1",
-    "d2l-discovery-fra": "github:Brightspace/discovery-fra#bsi-temp-fix",
+    "d2l-discovery-fra": "github:Brightspace/discovery-fra#semver:^3",
     "d2l-engagement-dashboard": "github:Brightspace/insights-engagement-dashboard#semver:^1",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-fetch-auth": "^1",


### PR DESCRIPTION
As the title suggests, the Discover dependency was updated to no longer use the temporary branch and instead use the latest release of it's bsi version (currently 3.0.2)