### PR TITLE
Bump discover-fra for routing update and remove labs facet filter sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,20 +1138,6 @@
         "lit-element": "^2"
       }
     },
-    "@brightspace-ui-labs/facet-filter-sort": {
-      "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
-      "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
-      "dev": true,
-      "requires": {
-        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
-        "@brightspace-ui/core": "^1",
-        "@polymer/polymer": "^3",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-        "lit-element": "^2"
-      }
-    },
     "@brightspace-ui-labs/file-uploader": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/file-uploader/-/file-uploader-2.0.2.tgz",
@@ -4922,11 +4908,10 @@
       }
     },
     "d2l-discovery-fra": {
-      "version": "github:Brightspace/discovery-fra#587caac9d886bf3187afdc8522bdf84747da2a45",
+      "version": "github:Brightspace/discovery-fra#f5ce84e0481a4cb628bf8d5a8613e4625c3135d4",
       "from": "github:Brightspace/discovery-fra#semver:^3",
       "dev": true,
       "requires": {
-        "@brightspace-ui-labs/facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "@brightspace-ui-labs/pagination": "^1",
         "@brightspace-ui/core": "^1.102.5",
         "@polymer/app-route": "^3.0.0-pre.15",
@@ -4947,6 +4932,7 @@
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "dompurify": "^2.2.2",
         "fastdom": "^1.0.8",
+        "lit-element-router": "^2.0.3",
         "promise-polyfill": "8.1.0",
         "siren-parser": "^8.2.0",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
@@ -8986,6 +8972,12 @@
       "requires": {
         "lit-html": "^1.1.1"
       }
+    },
+    "lit-element-router": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lit-element-router/-/lit-element-router-2.0.3.tgz",
+      "integrity": "sha512-ASaFeB5E4hsd2LYH3keY3ImuaW1+Dc3BcjauTRZhVcYmEIYDkIs/ci7Vfv/SroHhbyQ5nF/nPFBcOFipYsGwXg==",
+      "dev": true
     },
     "lit-html": {
       "version": "1.3.0",


### PR DESCRIPTION
This PR bumps to include new features in the BSI version of Discover, including routing via lit-element-router. Also removes the labs `facet-filter-sort` dependency, leaving only the core version of this dependency.