### PR TITLE
Update Brightspace-ui/core version to 1.100.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,9 +1292,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.100.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.100.3.tgz",
-      "integrity": "sha512-I59dUQQPhif/O4ix1Jcjle2q3/sD56iQ9wwTonHM4VfXX02xuo1rYIgigY3Um7YzZT3CS68DRbk0HjF5YeWEVw==",
+      "version": "1.100.4",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.100.4.tgz",
+      "integrity": "sha512-ZQzkn7pkRWocJDhEAAoa7hQtBarIlS7VfY4RSHt4FGoh+q2BXEe5dZu0QozyaaDJm/9tICHo/OEnIlXx15m+bA==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
For DE41464 -  FACE Calendar gets cutoff while in mobile drawer
https://rally1.rallydev.com/#/detail/defect/458814880188?fdp=true