### PR TITLE
engagement dashboard bump for 20.20.12 translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5080,8 +5080,8 @@
       }
     },
     "d2l-engagement-dashboard": {
-      "version": "github:Brightspace/insights-engagement-dashboard#7ae47619f65b2f7b7e3235b3c8f63fd9ae8e7db3",
-      "from": "github:Brightspace/insights-engagement-dashboard#semver:^1",
+      "version": "github:Brightspace/insights-engagement-dashboard#ed77322f0d8506a2a6c2dfb043b67cc37a450ef1",
+      "from": "github:Brightspace/insights-engagement-dashboard#semver:1.2012.3",
       "dev": true,
       "requires": {
         "@adobe/lit-mobx": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "d2l-content-store-add-content": "Brightspace/content-store-add-content#semver:^0",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^1",
     "d2l-discovery-fra": "github:Brightspace/discovery-fra#semver:^3",
-    "d2l-engagement-dashboard": "github:Brightspace/insights-engagement-dashboard#semver:^1",
+    "d2l-engagement-dashboard": "github:Brightspace/insights-engagement-dashboard#semver:1.2012.3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-fetch-auth": "^1",
     "d2l-fetch-dedupe": "^1",


### PR DESCRIPTION
Tested locally: checked Portuguese translations and verified new features (settings page) not included.