### PR TITLE
Add static TinyMCE plugins/styles to BSI for the HTML editor component

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -117,6 +117,7 @@ const appFiles = [
 // NOTE: Ideally these should all be dynamically imported by apps.
 //       Please don't add new entries to this list.
 const staticFiles = [
+	'node_modules/@brightspace-ui/htmleditor/tinymce/**',
 	'node_modules/@d2l/d2l-attachment/locales/*.json',
 	'node_modules/@d2l/d2l-attachment/icons/*.svg',
 	'node_modules/d2l-activities/components/d2l-activity-collection-editor/lang/*.js',


### PR DESCRIPTION
TinyMCE only provides their free offerings in their NPM packages. Since the HTML editor component relies on plugins and skins from their Enterprise subscription offering (which we need to download directly), we need to manually add these to the editor repo. Unfortunately, because TinyMCE needs to use these files directly, we can't import them and need to add them to rollup as static files. ☹️ 