### PR TITLE
Add d2l-quick-eval-widget

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -104,6 +104,7 @@ const appFiles = [
 	'./web-components/d2l-outcomes-user-progress.js',
 	'./web-components/d2l-program-outcomes-picker.js',
 	'./web-components/d2l-quick-eval.js',
+	'./web-components/d2l-quick-eval-widget.js',
 	'./web-components/d2l-content-store.js',
 	'./node_modules/d2l-content-store-add-content/d2l-content-store-add-content.js',
 	'./web-components/d2l-capture-central.js',

--- a/web-components/d2l-quick-eval-widget.js
+++ b/web-components/d2l-quick-eval-widget.js
@@ -1,0 +1,1 @@
+import 'd2l-activities/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js';


### PR DESCRIPTION
This PR adds the `d2l-quick-eval-widget` application to BSI. It's already contained in `activities` so no need to change `package.json`