### PR TITLE
[HOTFIX] 20.20.12 - Bump d2l-outcomes-overall-achievement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,7 +4917,7 @@
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-hypermedia-constants": "^6.36.0",
         "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
-        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
+        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
         "d2l-rubric": "github:Brightspace/d2l-rubric#semver:^3",
         "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",
         "lit-element": "^2",
@@ -5456,8 +5456,8 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#1f428b476afd4328f57f848090db8e92fd1c5f53",
-      "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#5b1cd874d88a0c3ae9b0a61cdf3cdb8d995e430d",
+      "from": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1.98.0",
@@ -5484,7 +5484,7 @@
         "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-more-less": "github:BrightspaceUI/more-less#semver:^5",
-        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
+        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,7 +4917,7 @@
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-hypermedia-constants": "^6.36.0",
         "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
-        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
+        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#v1.1.33-20.20.12-hotfix-1",
         "d2l-rubric": "github:Brightspace/d2l-rubric#semver:^3",
         "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",
         "lit-element": "^2",
@@ -5457,7 +5457,7 @@
     },
     "d2l-outcomes-overall-achievement": {
       "version": "github:Brightspace/d2l-outcomes-overall-achievement#5b1cd874d88a0c3ae9b0a61cdf3cdb8d995e430d",
-      "from": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
+      "from": "github:Brightspace/d2l-outcomes-overall-achievement#v1.1.33-20.20.12-hotfix-1",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1.98.0",
@@ -5484,7 +5484,7 @@
         "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-more-less": "github:BrightspaceUI/more-less#semver:^5",
-        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#20.20.12-v1.1.33",
+        "d2l-outcomes-overall-achievement": "github:Brightspace/d2l-outcomes-overall-achievement#v1.1.33-20.20.12-hotfix-1",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5456,7 +5456,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#8b99528c413baa1e377ec8d6d1419a34a1c07bf8",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#1f428b476afd4328f57f848090db8e92fd1c5f53",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^3",
-    "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#20.20.12-v1.1.33",
+    "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#v1.1.33-20.20.12-hotfix-1",
     "d2l-outcomes-user-progress": "Brightspace/d2l-outcomes-user-progress.git#semver:^1",
     "d2l-program-outcomes-picker": "Brightspace/program-outcomes-picker#semver:^3",
     "d2l-resize-aware": "BrightspaceUI/resize-aware.git#semver:^1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^3",
-    "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#semver:^1",
+    "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#20.20.12-v1.1.33",
     "d2l-outcomes-user-progress": "Brightspace/d2l-outcomes-user-progress.git#semver:^1",
     "d2l-program-outcomes-picker": "Brightspace/program-outcomes-picker#semver:^3",
     "d2l-resize-aware": "BrightspaceUI/resize-aware.git#semver:^1",


### PR DESCRIPTION
Reason for hotfix:
Translations for "overall achievement" were not being applied - required for international accessibility. Fixed in latest release of d2l-outcomes-overall-achievement, and separately applied to a hotfix release.

Ticket: https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fdefect%2F462843020492
Related PR: Brightspace/d2l-outcomes-overall-achievement#69

Hotfix release: https://github.com/Brightspace/d2l-outcomes-overall-achievement/releases/tag/20.20.12-v1.1.33