### PR TITLE
Update sequences version for 20.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5570,7 +5570,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#31f37540d493191fa96c5cc1f44d7c6912fa5764",
+      "version": "github:BrightspaceHypermediaComponents/sequences#6fd10b759e249cccefd380f9b4ca086003b0697f",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "dev": true,
       "requires": {


### PR DESCRIPTION
This is for 2 cert defects
- [DE41695](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F463898537708&fdp=true?fdp=true)
- [DE41590](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F461078835524&fdp=true?fdp=true) 