### PR TITLE
bump consistent-eval to 1.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4831,7 +4831,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#d8aeb9ca1b28088d5ad9aa5c13700ee1284d0143",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#7191c2f8bb8cdbc8c33be899620d6e68674f6ed9",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Backporting translations: https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/commits/master