### PR TITLE
Manually bump d2l-activities for hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4603,7 +4603,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#98315bec99764e9d7dfd7f488de0ea828c4d7236",
+      "version": "github:BrightspaceHypermediaComponents/activities#743e9443f74ff71a6894fe461c56260f15aa78bc",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/defect/484000074416

Bumping d2l-activities version for a hotfix related to assignment skeleton loading behaviour.