### PR TITLE
[Cert Fix 20.21.2] OSLO > Manual activities version bump to fix missing serge entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,7 +4610,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#61439ceeb37add8cd8419fcd497dd8e2ee5b8045",
+      "version": "github:BrightspaceHypermediaComponents/activities#9937517e1627e9246afd013f35bb58696b079b94",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Pulling in the change described in https://github.com/BrightspaceHypermediaComponents/activities/pull/1388