### PR TITLE
[Cert fix 20.21.2] activities version bump for weblink changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,7 +4610,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#9937517e1627e9246afd013f35bb58696b079b94",
+      "version": "github:BrightspaceHypermediaComponents/activities#dfb3774c52aa02c8333f6ffeb1fe8daa41a7cb33",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Changes [can be found here](https://github.com/BrightspaceHypermediaComponents/activities/pull/1422).