### PR TITLE
Update for d2l-input-textarea.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,16 +1221,6 @@
         "lit-element": "^2"
       }
     },
-    "@brightspace-ui-labs/role-selector": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/role-selector/-/role-selector-1.1.5.tgz",
-      "integrity": "sha512-X8qsuSab48MvBQVVE8eOiVvH+pAOkM13hSrcO/WX8aGF2Hiw6N1TEd55CgXIFgphSr6GmpvvzEdgobqVtqbWQA==",
-      "dev": true,
-      "requires": {
-        "@brightspace-ui/core": "^1.80.1",
-        "lit-element": "^2"
-      }
-    },
     "@brightspace-ui-labs/user-feedback": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/user-feedback/-/user-feedback-1.0.14.tgz",
@@ -1266,18 +1256,6 @@
       "requires": {
         "@brightspace-ui/core": "^1",
         "lit-element": "^2"
-      }
-    },
-    "@brightspace-ui-labs/wizard": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/wizard/-/wizard-1.2.3.tgz",
-      "integrity": "sha512-0JePHQUvBRT2tZWCdMUKbhcgnBskStddrO5fJOnBTK4p7E2ZTHVMLntnhirEiL08NB2gLD759bnl9bWal4EsZA==",
-      "dev": true,
-      "requires": {
-        "@brightspace-ui/core": "^1.92.0",
-        "@webcomponents/webcomponentsjs": "^2.4.1",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "lit-element": "^2.2.1"
       }
     },
     "@brightspace-ui/core": {
@@ -1928,16 +1906,6 @@
         "polyfills-loader": "^1.7.5"
       }
     },
-    "@polymer/app-route": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/app-route/-/app-route-3.0.2.tgz",
-      "integrity": "sha512-8Y34evmsaYh7ONr+zLwLzXaU0iOZZQj1E2uB3iaToQHbOP1POhKlnmAycBQ/eFB8BwrdSUBaDQk+rZhio78FQw==",
-      "dev": true,
-      "requires": {
-        "@polymer/iron-location": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/font-roboto": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
@@ -2080,15 +2048,6 @@
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
         "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-location": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-location/-/iron-location-3.0.2.tgz",
-      "integrity": "sha512-75XlPsrm6RQUPNzWWaA0TnTQaWZUYX8UB4Q6WCjikKWzmaSCCxlBrVVYf8WRqtCxw/PeCvLn5kGL6qhTlNTCEA==",
-      "dev": true,
-      "requires": {
         "@polymer/polymer": "^3.0.0"
       }
     },
@@ -4709,20 +4668,6 @@
         "polymer-cli": "^1.9.11"
       }
     },
-    "d2l-ads-scheduler": {
-      "version": "github:Brightspace/custom-ads-scheduler#ce52457ebef242ac629ea919af64bf166f77ce09",
-      "from": "github:Brightspace/custom-ads-scheduler#semver:^1",
-      "dev": true,
-      "requires": {
-        "@brightspace-ui-labs/pagination": "^1",
-        "@brightspace-ui-labs/role-selector": "^1.1.4",
-        "@brightspace-ui-labs/wizard": "^1.2.2",
-        "@brightspace-ui/core": "^1.92.0",
-        "@brightspace-ui/intl": "^3.0.11",
-        "@webcomponents/webcomponentsjs": "^2",
-        "lit-element": "^2"
-      }
-    },
     "d2l-alert": {
       "version": "github:BrightspaceUI/alert#3ca1e0029c3201461e1415d77b3ea7140fc3e9ac",
       "from": "github:BrightspaceUI/alert#semver:^4",
@@ -4972,38 +4917,6 @@
         "d2l-time-picker": "github:BrightspaceUI/time-picker#semver:^2",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
-      }
-    },
-    "d2l-discovery-fra": {
-      "version": "github:Brightspace/discovery-fra#84c8787a99dc7a8fa0ec423f656934b2cb6dbd89",
-      "from": "github:Brightspace/discovery-fra#semver:^3",
-      "dev": true,
-      "requires": {
-        "@brightspace-ui-labs/facet-filter-sort": "^4",
-        "@brightspace-ui-labs/pagination": "^1",
-        "@brightspace-ui/core": "^1.102.5",
-        "@polymer/app-route": "^3.0.0-pre.15",
-        "@polymer/iron-pages": "^3.0.0-pre.15",
-        "@polymer/iron-resizable-behavior": "^3.0.0",
-        "@polymer/polymer": "^3",
-        "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",
-        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-        "d2l-fetch-auth": "^1",
-        "d2l-fetch-dedupe": "^1.3.0",
-        "d2l-hypermedia-constants": "^6",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
-        "d2l-organization-hm-behavior": "github:Brightspace/organization-hm-behavior#semver:^3",
-        "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-        "dompurify": "^2.2.2",
-        "fastdom": "^1.0.8",
-        "lit-element-router": "^2.0.3",
-        "promise-polyfill": "8.1.0",
-        "siren-parser": "^8.2.0",
-        "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
-        "url-polyfill": "^1.1.12",
-        "whatwg-fetch": "^3.5.0"
       }
     },
     "d2l-dnd-sortable": {
@@ -5329,16 +5242,13 @@
       }
     },
     "d2l-opt-in-flyout-webcomponent": {
-      "version": "github:Brightspace/d2l-opt-in-flyout-webcomponent#441f502fd2cb38005ad6eb7e1b739fd7636915c3",
-      "from": "github:Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
+      "version": "github:BrightspaceUILabs/opt-in-flyout#631d58ba55d7bfaa11e81d5586f712214bf5cccc",
+      "from": "github:BrightspaceUILabs/opt-in-flyout#semver:^2",
       "dev": true,
       "requires": {
+        "@brightspace-ui/core": "^1.113.4",
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#semver:^5",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "s-html": "github:Brightspace/s-html#semver:^2"
       }
@@ -5497,12 +5407,12 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#affbf9b2f7ca8fc117da2bad9b2ca1fd0e36c1ad",
+      "version": "github:Brightspace/d2l-rubric#c41cbe32db7efba377d10e8d61ce59d7577a79ed",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "dev": true,
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
-        "@brightspace-ui/core": "^1.30.1",
+        "@brightspace-ui/core": "^1.113.5",
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/iron-overlay-behavior": "^3.0.2",
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -5962,12 +5872,6 @@
       "requires": {
         "domelementtype": "^2.0.1"
       }
-    },
-    "dompurify": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
-      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ==",
-      "dev": true
     },
     "domutils": {
       "version": "2.4.4",
@@ -8804,12 +8708,6 @@
       "requires": {
         "lit-html": "^1.1.1"
       }
-    },
-    "lit-element-router": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lit-element-router/-/lit-element-router-2.0.3.tgz",
-      "integrity": "sha512-ASaFeB5E4hsd2LYH3keY3ImuaW1+Dc3BcjauTRZhVcYmEIYDkIs/ci7Vfv/SroHhbyQ5nF/nPFBcOFipYsGwXg==",
-      "dev": true
     },
     "lit-html": {
       "version": "1.3.0",
@@ -25002,12 +24900,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA==",
-      "dev": true
-    },
     "promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -27318,12 +27210,6 @@
           "dev": true
         }
       }
-    },
-    "url-polyfill": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
-      "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==",
-      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "d2l-my-courses": "Brightspace/d2l-my-courses-ui#semver:^11",
     "d2l-my-dashboards": "github:Brightspace/d2l-my-dashboards-ui#semver:^3",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
-    "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
+    "d2l-opt-in-flyout-webcomponent": "BrightspaceUILabs/opt-in-flyout#semver:^2",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^3",
     "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#semver:^1",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -33,6 +33,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/inputs/input-number.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-search.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-text.js',
+	'./node_modules/@brightspace-ui/core/components/inputs/input-textarea.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time-range.js',
 	'./node_modules/@brightspace-ui/core/components/loading-spinner/loading-spinner.js',


### PR DESCRIPTION
* exposes core's d2l-input-textarea in rollup config
* updates dependency for d2l-opt-in-flyout-webcomponent since it was renamed
* updates to package-lock.json to pull in revised versions of opt-in and rubrics