### PR TITLE
Updates for d2l-input-textarea from core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5329,8 +5329,8 @@
       }
     },
     "d2l-opt-in-flyout-webcomponent": {
-      "version": "github:Brightspace/d2l-opt-in-flyout-webcomponent#631d58ba55d7bfaa11e81d5586f712214bf5cccc",
-      "from": "github:Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
+      "version": "github:BrightspaceUILabs/opt-in-flyout#631d58ba55d7bfaa11e81d5586f712214bf5cccc",
+      "from": "github:BrightspaceUILabs/opt-in-flyout#semver:^2",
       "dev": true,
       "requires": {
         "@brightspace-ui/core": "^1.113.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "d2l-my-courses": "Brightspace/d2l-my-courses-ui#semver:^11",
     "d2l-my-dashboards": "github:Brightspace/d2l-my-dashboards-ui#semver:^3",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
-    "d2l-opt-in-flyout-webcomponent": "Brightspace/d2l-opt-in-flyout-webcomponent#semver:^2",
+    "d2l-opt-in-flyout-webcomponent": "BrightspaceUILabs/opt-in-flyout#semver:^2",
     "d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^5",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui.git#semver:^3",
     "d2l-outcomes-overall-achievement": "Brightspace/d2l-outcomes-overall-achievement.git#semver:^1",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -33,6 +33,7 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui/core/components/inputs/input-number.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-search.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-text.js',
+	'./node_modules/@brightspace-ui/core/components/inputs/input-textarea.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time.js',
 	'./node_modules/@brightspace-ui/core/components/inputs/input-time-range.js',
 	'./node_modules/@brightspace-ui/core/components/loading-spinner/loading-spinner.js',


### PR DESCRIPTION
* updates dependency for d2l-opt-in-flyout since it was moved
* adds core d2l-input-textarea to roll-up config so it can be referenced in LMS

Note: a second PR will be made to remove `./node_modules/d2l-inputs/d2l-input-textarea.js` from the rollup config once it's reference in the LMS has been updated. (https://search.d2l.dev/xref/lms/mp/D2L.WCS.MP.Web/Assets/InputTextareaModule.codegen?r=3a00a5b5)