### PR TITLE
remove Firefox ESR from our browserlist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,4 @@
 last 2 versions
-Firefox ESR
 Edge 18
 not IE 11
 ios_saf >= 10


### PR DESCRIPTION
We dropped support for the Extended Support Release of Firefox with the January release. Removing it from here will cause old-Firefox vendor prefixes from appearing in our CSS and stop Babel from doing special JS transpiling specifically for Firefox ESR.