### PR TITLE
Expose module for mathJax loader.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,9 +1281,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.113.7",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.113.7.tgz",
-      "integrity": "sha512-nRLiiMAcJVDG22PSqQw2kaaxO5myMk6KhZriAVx2ROIGI0WadCw2PX7nGjEAzdEN/VQGr2c+shST9LT0OpV21Q==",
+      "version": "1.114.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.114.0.tgz",
+      "integrity": "sha512-3zHDPW5Te/7Ba+aDJxnzGmeIJmrbhm5PYIEM/GpG6VnplOwQI7eiRER34iBVLFOssLtdpZZx65JwNMcVIE3SiA==",
       "dev": true,
       "requires": {
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@brightspace-ui-labs/media-player": "^1",
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui-labs/user-feedback": "^1",
-    "@brightspace-ui/core": "^1.78.0",
+    "@brightspace-ui/core": "^1.114.0",
     "@brightspace-ui/htmleditor": "^1",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -77,7 +77,8 @@ const componentFiles = [
 	'./web-components/d2l-simple-overlay.js',
 	'./web-components/d2l-table.js',
 	'./web-components/d2l-tabs.js',
-	'./web-components/intl-messageformat-parser.js'
+	'./web-components/intl-messageformat-parser.js',
+	'./web-components/mathjax.js'
 ];
 const appFiles = [
 	'./node_modules/@brightspace-hmc/foundation-components/components/activity/editor/d2l-hc-activity-editor.js',

--- a/web-components/mathjax.js
+++ b/web-components/mathjax.js
@@ -1,0 +1,6 @@
+import { loadMathJax } from '@brightspace-ui/core/helpers/mathjax.js';
+
+window.D2L = window.D2L || {};
+window.D2L.MathJax = {
+	loadMathJax: loadMathJax
+};


### PR DESCRIPTION
This PR exposes the mathJax loader as a module that can be imported from the LMS (for Equation Editors), and also Content Topics. It is not included in `bsi-unbundled.js` because it will only be needed in those contexts, and it needs to be loadable on its own with out the other stuff that's in `bsi-unbundled.js`. The loader will have future changes to support configuration, but this one step towards hooking things up.

This PR is required for this LMS PR: https://github.com/Brightspace/lms/pull/5920
