### PR TITLE
update CE to 1.39.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4837,7 +4837,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#d1d13d55c5384b6d68367a0439ab33faf06c2350",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#2c5abcf46be1ff63daa6a1ba2c2ddd61da881863",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/releases/tag/v1.39.3