### PR TITLE
DE42328 - Update translations for d2l-outcomes-overall-achievement (20.21.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5386,7 +5386,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#c376b91f390620e2159daebdc1d9befd6f6899cd",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#10d68559e86bf7c854f141f68eb06a23c5753120",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Adding all but **Welsh** in case we don't get it by EOD. This at least gets us all languages but **Welsh** updated for `20.21.2`.

Uses: https://github.com/Brightspace/d2l-outcomes-overall-achievement/releases/tag/v1.1.42-20.21.2-hotfix-2