### PR TITLE
[Cert fix 20.21.3] W2D: Activities w/o start dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,7 +4492,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#724da42878c055342682bc066b31aed262330361",
+      "version": "github:BrightspaceHypermediaComponents/activities#efc4ef36b60ae03e750d0ebc27aec73013260854",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
Activities without start dates were not clickable, this fixes that - see corresponding change in https://github.com/BrightspaceHypermediaComponents/activities/pull/1516
rally ticket: https://rally1.rallydev.com/#/357251704080ud/workviews?Name=Activities%20are%20no%20longer%20clickable%20&Priority=High&Project=%2Fproject%2F357251704080&Requirement=%2Fhierarchicalrequirement%2F459574112788&Severity=Major%20Problem&detail=%2Fdefect%2F499184063304&iteration=u&parentRef=%2Fhierarchicalrequirement%2F459574112788&rankTo=BOTTOM&view=b064b584-6337-43c1-b9a9-28047568284d&fdp=true?fdp=true