### PR TITLE
Add support for dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,6 +2208,52 @@
         "resolve": "^1.11.0"
       }
     },
+    "@rollup/plugin-dynamic-import-vars": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-dynamic-import-vars/-/plugin-dynamic-import-vars-1.1.1.tgz",
+      "integrity": "sha512-PqdfEKlsyPx0hPSSuOigCHgrQbOLW+y09KRRCFeWiBBnkuh4LlV6mfrDefmLQijj8XCWzyLct2rK+q89qvRp7A==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "globby": "^11.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        },
+        "globby": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@octokit/rest": "^17",
     "@open-wc/building-rollup": "^1",
     "@rollup/plugin-commonjs": "^11",
+    "@rollup/plugin-dynamic-import-vars": "^1.1.1",
     "@rollup/plugin-replace": "^2",
     "autoprefixer": "^9",
     "babel-eslint": "^10",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -1,6 +1,7 @@
 import { createBasicConfig } from '@open-wc/building-rollup';
 import copy from 'rollup-plugin-copy';
 import replace from '@rollup/plugin-replace';
+import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import merge from 'deepmerge';
 
 const componentFiles = [
@@ -157,6 +158,9 @@ export default merge(config, {
 		replace({
 			define: 'defineNoYouDont', /* prevents UMD time bomb as fastdom will try to call define() on UMD FRA pages */
 			include: ['node_modules/fastdom/fastdom.js', 'node_modules/focus-visible/dist/focus-visible.js']
+		}),
+		dynamicImportVars({
+			exclude: 'node_modules/d2l-html-editor/d2l-html-editor.js',
 		})
 	]
 });


### PR DESCRIPTION
[This plugin](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#how-it-works) allows for the use of dynamic `import` statements by replacing variables with glob patterns to find and add files to the build. It then creates a `switch` to handle each case.