### PR TITLE
Switch back to previous ghworkflow branch name

### DIFF
--- a/.github/workflows/bsi-update.yml
+++ b/.github/workflows/bsi-update.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
 
     env:
-      BRANCH_NAME: fixing_gh_auto_update
+      BRANCH_NAME: ghworkflow/bsi_auto_update
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Going to let this trigger a BSI release this time, and see if the LMS's sync job is also broken.