### PR TITLE
Update d2l-rubric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5308,7 +5308,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#de1c69a82610d066b57798f94554f419d129bfbf",
+      "version": "github:Brightspace/d2l-rubric#833ee01ce2a054ecaf6568603e09bb280f03b74d",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
Pick up new translations. Update to [v3.7.45-20.21.3-cert-1](https://github.com/Brightspace/d2l-rubric/releases/tag/v3.7.45-20.21.3-cert-1) release.