### PR TITLE
DE42251 Adding es-ES language to the oslo xml file

### DIFF
--- a/oslo/generate-monolith-xml
+++ b/oslo/generate-monolith-xml
@@ -13,6 +13,7 @@ const Languages = [
 	new Lang('ar-sa', 'ar', 'ar-SA'),
 	new Lang('da-dk', 'da', 'da-DK'),
 	new Lang('de-de', 'de', 'de-DE'),
+	new Lang('es-es', 'es-es', 'es-ES'),
 	new Lang('es-mx', 'es', 'es-MX'),
 	new Lang('fr-ca', 'fr', 'fr-CA'),
 	new Lang('ja-jp', 'ja', 'ja-JP'),


### PR DESCRIPTION
[DE42251](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F488586858356&fdp=true?fdp=true) 

I don't fully have this mapped out about what I need to do to make this work end to end, but I know certain steps are necessary to start, this being one of them. Once I get this BSI change in I can start to test how this maps to the lms build with [`Instal-Oslo.ps1`](https://github.com/Brightspace/lms/blob/master/lp/build/Install-Oslo.ps1) as there are already certain components with es-ES enabled in their serge files.

Currently known list of tasks for this defect:
1. Add `es-ES` to the oslo part of BSI (this PR)
2. Add `es-ES` to the relevant serge files in the repos (namely activities, attachments)
3. Update [`Instal-Oslo.ps1`](https://github.com/Brightspace/lms/blob/master/lp/build/Install-Oslo.ps1) with `es-ES` type and ensure the build maps this to the correct language.