### PR TITLE
handle scripts trying to access process.env.NODE_ENV, specifically mobx

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -165,7 +165,12 @@ export default merge(config, {
 		}),
 		replace({
 			define: 'defineNoYouDont', /* prevents UMD time bomb as fastdom will try to call define() on UMD FRA pages */
-			include: ['node_modules/fastdom/fastdom.js', 'node_modules/focus-visible/dist/focus-visible.js']
+			include: ['node_modules/fastdom/fastdom.js', 'node_modules/focus-visible/dist/focus-visible.js'],
+			preventAssignment: true
+		}),
+		replace({
+			'process.env.NODE_ENV': JSON.stringify('production'),
+			preventAssignment: true
 		}),
 		dynamicImportVars({
 			exclude: 'node_modules/d2l-html-editor/d2l-html-editor.js',


### PR DESCRIPTION
Certain client-side scripts have conditional code/logic keyed off `process.env.NODE_ENV`. Specifically React likes to do this, as does `mobx`.

`mobx` gets pretty cranky if it doesn't see "production" in there... specifically it's getting `undefined`, so it complains thus:
> [mobx] you are running a minified build, but 'process.env.NODE_ENV' was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle

Looking for `process.env.NODE_ENV` is so common that the [replace Rollup plugin](https://github.com/rollup/plugins/tree/master/packages/replace#usage) uses this as its main example for using it. So this is the approach I've taken to address it.

While I was in here, I noticed warnings about the `preventAssignment` option soon defaulting to `true` and we should start using that as soon as possible, so I've enabled it. More on that [and why it's a good idea](https://github.com/rollup/plugins/tree/master/packages/replace#preventassignment).

