### PR TITLE
upgrading table to 2.4.4 to pick up fix for sticky headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5615,7 +5615,7 @@
       }
     },
     "d2l-table": {
-      "version": "github:BrightspaceUI/table#bd6e3de0ccf3f855ad22d4fef1e2e85352b93415",
+      "version": "github:BrightspaceUI/table#25ad5467b3ab146f73a1cb752e252387c989c5b8",
       "from": "github:BrightspaceUI/table#semver:^2",
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
This adds the [changes from this PR](https://github.com/BrightspaceUI/table/pull/227) to fix an issue with column overlap in sticky headers in the cert stage of `20.21.4`.