### PR TITLE
Bumped activities for certfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4678,7 +4678,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#28568615ef611cc8556f819bd96510e0c636f541",
+      "version": "github:BrightspaceHypermediaComponents/activities#aabd3bd4fb80c006da0cfb3a958b359ba172e2f7",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
Manually bumping BSI for certfix. Should now be pointing to this commit: https://github.com/BrightspaceHypermediaComponents/activities/commit/aabd3bd4fb80c006da0cfb3a958b359ba172e2f7

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F514561889664

