### PR TITLE
removing offset now that -10 is the default

### DIFF
--- a/web-components/d2l-table.js
+++ b/web-components/d2l-table.js
@@ -3,9 +3,6 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
 	<style is="custom-style" include="d2l-table-style">
-		.d2l-dialog-body d2l-table-wrapper {
-			--d2l-scroll-wrapper-action-offset: -10px;
-		}
 		.d2l-grid-mvc > * > tr > td {
 			vertical-align: top;
 		}


### PR DESCRIPTION
As per [this change](https://github.com/BrightspaceUI/table/pull/233), `-10px` is now the default so no need for this code.