### PR TITLE
bump ce to 1.115.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4889,7 +4889,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#1d8817b224217c6ad00dc9bdd8ff7ed9bb9666af",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#98ac0f9513d0ab05a8693de2dfec8df1ab2525fa",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/grade-result": "^1.0.5",


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/releases/tag/v1.115.2