### PR TITLE
Replacing the erroneous sample button with the actual rule component

### DIFF
--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -90,7 +90,7 @@ const appFiles = [
 	'./node_modules/@brightspace/content-components/components/d2l-content-store/d2l-content-store.js',
 	'./node_modules/@brightspace/content-components/components/d2l-capture-central/d2l-capture-central.js',
 	'./node_modules/@brightspace-hmc/foundation-components/components/activity/editor/d2l-hc-activity-editor.js',
-	'./node_modules/@brightspace-hmc/foundation-components/features/discover/d2l-discover-sample-button.js',
+	'./node_modules/@brightspace-hmc/foundation-components/features/discover/d2l-discover-rules.js',
 	'./node_modules/d2l-activities/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js',
 	'./node_modules/d2l-activities/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js',
 	'./node_modules/@brightspace-hmc/foundation-components/features/workToDo/d2l-w2d-work-to-do.js',


### PR DESCRIPTION
[US123773](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F480102056300&fdp=true?fdp=true)
Replacing the `discover-sample-button` with the `discover-rules` component.