### PR TITLE
upgrading core and table for sticky headers fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1377,9 +1377,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.118.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.118.3.tgz",
-      "integrity": "sha512-KXFE3FpT8Zq5JN0aT+qbKurfv3YC75+awPAZ9SXGaFBKupkn1TOyrxSzg2IEzXzlJI91r+RZeUBpV4I9WiaqAQ==",
+      "version": "1.118.4",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.118.4.tgz",
+      "integrity": "sha512-Z/P7D3qynezRGQWnKgkKWWkQyUohsuXSHv4Rv1nviuIn4dNws6HVseEZGJ9nGON0vOLl+3qJPkXtiJZeYtUOjg==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -5615,8 +5615,8 @@
       }
     },
     "d2l-table": {
-      "version": "github:BrightspaceUI/table#25ad5467b3ab146f73a1cb752e252387c989c5b8",
-      "from": "github:BrightspaceUI/table#semver:^2",
+      "version": "github:BrightspaceUI/table#a5e357df16b006c84530d42887a77b2b465ee203",
+      "from": "github:BrightspaceUI/table#semver:2.4.5",
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",


### PR DESCRIPTION
This cert fixes the grades sticky header issue. Technically the core change isn't needed since our numeric-input web component flag isn't on, but it's not doing anything.