### PR TITLE
DE43118 - Update BSI to use hotfixed version of the HTML editor component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,9 +1393,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.3.1.tgz",
-      "integrity": "sha512-CWXqv9xIutb6CVEspXofGqhisT0DigLWl9D1+a1yXInYYIajXWEYS1FQjbvdDP4nIZVGpKuw1jgewFzAOsqi/w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.5.2.tgz",
+      "integrity": "sha512-Zcsr0iTwt019BLc1U5R7pfx9LGAQ3ltDuXTZyON/f704esZTLE8icraGbJ/05FQanDHd1IW7/khLDrK/wImbCw==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui-labs/user-feedback": "^1",
     "@brightspace-ui/core": "^1.114.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "~1.5",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",
     "@brightspace-hmc/foundation-components": "BrightspaceHypermediaComponents/foundation-components.git#semver:^0",


### PR DESCRIPTION
I... Don't entirely know if I've done this right, so if I haven't please feel free to yell at me. The editor needed to be hotfixed to include a fix to ISF (https://github.com/BrightspaceUI/htmleditor/pull/155).

This also contains two unrelated commits (1.4 and 1.5 of the editor respectively) that have the net result of introducing a new API. This shouldn't impact existing apps, but would let us backport an LMS-side fix that would need to use this new API if it turns out this is necessary. I would rather just bundle the changes together and get away with one BSI release as opposed to having to do another one later if it turns out we need to backport the API changes after all. If others disagree I'm open to changing this.