### PR TITLE
Bump htmleditor version in cert (contains % height fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.6.tgz",
-      "integrity": "sha512-KlTAyjQAcYQacbsiB0tUpD++rNV77q/lYo88iKXgV2zdEKivgtBdBCZeL62ookGOOG4Vp2rtTYEiW6Sqf/FG6A==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.7.tgz",
+      "integrity": "sha512-7ZT2EVn65wtmHSJpD5ssXq3Z6Q8slchpZYFRVp14uRny8v3sC5JRQb+fHMB1Fy/E8EmrQyuNj48HuTXXlj+A5A==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui-labs/user-feedback": "^1",
     "@brightspace-ui/core": "^1.114.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "~1.7",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",
     "@brightspace-hmc/foundation-components": "BrightspaceHypermediaComponents/foundation-components.git#semver:^0",


### PR DESCRIPTION
Didn't quite make branching on this HTML editor change last week. For reference, this is what we're backporting: https://github.com/BrightspaceUI/htmleditor/compare/v1.7.6...v1.7.7