### PR TITLE
[Cert] Update discover-fra to v3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4984,7 +4984,7 @@
       }
     },
     "d2l-discovery-fra": {
-      "version": "github:Brightspace/discovery-fra#6243f7ae4c834df59985ca13c2eff8cd2ac7b096",
+      "version": "github:Brightspace/discovery-fra#7461e1c6a1c07442d4425490433834c239fc9cc2",
       "from": "github:Brightspace/discovery-fra#semver:^3",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4",


### PR DESCRIPTION
This includes the fixes for [DE42852](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fdefect%2F510897356476)
Tested before and after updating package lock by using `npm ci` to confirm the changes take place as expected