### PR TITLE
Backport htmleditor a11y fixes, eqn editor fix, and translations to 20.21.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.7.tgz",
-      "integrity": "sha512-7ZT2EVn65wtmHSJpD5ssXq3Z6Q8slchpZYFRVp14uRny8v3sC5JRQb+fHMB1Fy/E8EmrQyuNj48HuTXXlj+A5A==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.9.tgz",
+      "integrity": "sha512-P1rwHHRiKfe0vFMAahBPFpWr7pflbMWaUd4pcK4A4t3hEA3XC4UxPwca9d2LoIKlCTnVhqQStVCjOI0qvTOfcw==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Change comparison: https://github.com/BrightspaceUI/htmleditor/compare/v1.7.7...v1.7.9

The 20.21.5 version of BSI is already looking for version ~1.7 of the editor so only the package lock needs changing here.