### PR TITLE
Remove references to button-group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,7 +1224,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#f7b78f5797b6febf022c2894c6c948d48e2cf0e0",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#53c6685f7e063b3e266f76c543ce18778cc009c5",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#ae14137273dc8ca27f0766c3de58c5028de6a81b",
+      "version": "github:BrightspaceHypermediaComponents/activities#3ab8a3d2b108d753c0767ff2ee738101b7c7eb51",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -4897,21 +4897,6 @@
       "requires": {
         "@brightspace-ui/core": "^1",
         "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "d2l-button-group": {
-      "version": "github:BrightspaceUI/button-group#100ee2c26445ce9a45bb82cbb09e8083b85a1ead",
-      "from": "github:BrightspaceUI/button-group#semver:^3",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#semver:^5",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
-        "fastdom": "^1.0.8"
       }
     },
     "d2l-card": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "d2l-activity-exemptions": "Brightspace/d2l-activity-exemptions#semver:^2",
     "d2l-ads-scheduler": "Brightspace/custom-ads-scheduler#semver:^1",
     "d2l-awards-leaderboard-ui": "Brightspace/awards-leaderboard-ui#semver:^1",
-    "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-consistent-evaluation": "BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
     "d2l-cpd": "Brightspace/continuous-professional-development#semver:^2",
     "d2l-discovery-fra": "github:Brightspace/discovery-fra#semver:^3",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -58,8 +58,6 @@ const componentFiles = [
 	'./node_modules/@brightspace-ui-labs/media-player/media-player.js',
 	'./node_modules/@brightspace-ui-labs/pagination/pagination.js',
 	'./node_modules/d2l-activities/components/d2l-subtitle/d2l-subtitle.js',
-	'./node_modules/d2l-button-group/d2l-button-group.js',
-	'./node_modules/d2l-button-group/d2l-action-button-group.js',
 	'./node_modules/d2l-navigation/d2l-navigation-band.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button-notification-icon.js',
 	'./node_modules/d2l-navigation/d2l-navigation-button.js',


### PR DESCRIPTION
Incremented the package version in the insights-engagement-dashboard and was able to remove all references to button-group in the package-lock. I think this is gone forever. 😄

