### PR TITLE
US127858 [AQ] New Temporary Assessment Quality Dashboard Page. Publish the dashboard to CDN

### DIFF
--- a/.serge-mapping.json
+++ b/.serge-mapping.json
@@ -1,6 +1,7 @@
 {
   "@d2l/d2l-attachment": "@d2l/d2l-attachment/d2l-attachment.serge.json",
   "d2l-activities": "d2l-activities/activities.serge.json",
+  "d2l-assessment-quality-dashboard": "d2l-assessment-quality-dashboard/insights-assessment-quality-dashboard.serge.json",
   "d2l-engagement-dashboard": "d2l-engagement-dashboard/insights-engagement-dashboard.serge.json",
   "@brightspace-hmc/foundation-components": "@brightspace-hmc/foundation-components/foundation-components.serge.json",
   "d2l-cpd": "d2l-cpd/continuous-professional-development.serge.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4864,7 +4864,7 @@
       }
     },
     "d2l-assessment-quality-dashboard": {
-      "version": "github:Brightspace/insights-assessment-quality-dashboard#441314b150815e06fa984b6b2c97202f07a212ef",
+      "version": "github:Brightspace/insights-assessment-quality-dashboard#a07b2fb55efb3f1363d6ad649eac0f3e58ddb365",
       "from": "github:Brightspace/insights-assessment-quality-dashboard#semver:^1",
       "requires": {
         "@adobe/lit-mobx": "0.0.x",

--- a/rollup/rollup-wc.config.js
+++ b/rollup/rollup-wc.config.js
@@ -94,6 +94,7 @@ const appFiles = [
 	'./node_modules/d2l-activities/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js',
 	'./node_modules/@brightspace-hmc/foundation-components/features/workToDo/d2l-w2d-work-to-do.js',
 	'./node_modules/@brightspace-hmc/foundation-components/features/lti/d2l-lti-activity.js',
+	'./node_modules/d2l-assessment-quality-dashboard/assessment-quality-dashboard.js',
 	'./node_modules/d2l-activities/components/d2l-work-to-do/d2l-work-to-do.js',
 	'./node_modules/d2l-engagement-dashboard/engagement-dashboard.js',
 	'./web-components/d2l-activity-alignments.js',


### PR DESCRIPTION
[US127858](https://rally1.rallydev.com/#/23525809118d/portfolioitemstreegrid?detail=%2Fuserstory%2F603047932448&fdp=true?fdp=true): [AQ] New Temporary Assessment Quality Dashboard Page

PR publishes the dashboard to CDN. It also registers repo for serge translations

FYI @anhill-D2L @hyehayes @johngwilkinson @NicholasHallman @bemailloux 