### PR TITLE
DE43573 - backporting latest siren SDK commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11888,7 +11888,7 @@
       "integrity": "sha512-mu6iERPU9mFVGL/fZoKMub51E6yuvfZmeFZhBWuHO5Vyuto3nKhbzk9RmGcFiny/MvNZu8ADHxOBWbtkQnW1nQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#75f86553daa6d1a961dc077d5fb1abf8b5aacc44",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#cc5f142ee34c41f5cd5ed4d596e6d8f264592a06",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
[DE43573](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F604787926432&fdp=true?fdp=true): [cert] Lessons FACE > HTML editor does not load on HTML Topic page

Updating BSI 20.21.6 to be pinned to the latest [Siren SDK]https://github.com/BrightspaceHypermediaComponents/siren-sdk/commits/master) commit