### PR TITLE
Bump htmleditor version to 1.7.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.9.tgz",
-      "integrity": "sha512-P1rwHHRiKfe0vFMAahBPFpWr7pflbMWaUd4pcK4A4t3hEA3XC4UxPwca9d2LoIKlCTnVhqQStVCjOI0qvTOfcw==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.10.tgz",
+      "integrity": "sha512-JjY8xiLq/xnuoC07t64Z2tuZ5vtCScZBFhxJ2L7QuoCx/7FgN22aMinAP4g1xMPYdjjPWxNcuSIctFjZQAJ4uQ==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains the following changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.7.9...v1.7.10