### PR TITLE
Backport activities and siren-sdk commits for html editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#7c1562c31aad3a983782d40e11f923216575ca60",
+      "version": "github:BrightspaceHypermediaComponents/activities#07d4fc031c217e4283798554acfaa1fbe8dc8967",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -11888,7 +11888,7 @@
       "integrity": "sha512-mu6iERPU9mFVGL/fZoKMub51E6yuvfZmeFZhBWuHO5Vyuto3nKhbzk9RmGcFiny/MvNZu8ADHxOBWbtkQnW1nQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#cc5f142ee34c41f5cd5ed4d596e6d8f264592a06",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#78bcc6d5edc1f6d8dd2eedf70e8d66e7a9cc67a9",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
Updating siren-sdk and activities for:
- [DE43588](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F605071055280&fdp=true): Default fonts in new HTML editor needs to be Verdana/Lato
- [DE43500](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F603973776280&fdp=true) FACE HTML > Head scripts are duplicated when saving html files

Using the latest[ commit from `siren-sdk`](https://github.com/BrightspaceHypermediaComponents/siren-sdk/commits/master) 
Using the latest [commit for the 20.21.6 activities release of 3.161.3 ](https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.161.3b)