### PR TITLE
Phoenix html editor backport branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#d5eeb6bf0294a924fe6f797023f244d01b2e2d52",
+      "version": "github:BrightspaceHypermediaComponents/activities#29a338df3b403743f3ad602c6c2d0cb76cea4058",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#07d4fc031c217e4283798554acfaa1fbe8dc8967",
+      "version": "github:BrightspaceHypermediaComponents/activities#d5eeb6bf0294a924fe6f797023f244d01b2e2d52",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43589](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F605074749528&fdp=true?fdp=true): [cert] FACE HTML > HTML file content saved as "undefined"
- [DE43565](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F604746646724&fdp=true?fdp=true): [cert] Lessons FACE Modules > HTML editor default size is too small



## Description

Backporting the fixes for the above 2 defects



## Goal/Solution

Backporting the fixes for the above 2 defects


## Video/Screenshots

N/A


## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1746
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1741



## Remaining Work

Update 20.21.6 LMS with the latest 20.21.6 BSI version after this is udpated