### PR TITLE
Bump activities for html editor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#957cc8b1d6c653f386421f0d220d53abe1dc1da1",
+      "version": "github:BrightspaceHypermediaComponents/activities#cf1b341f9bd754c910b8d708d8516b7838070c59",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43731](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F600345601867&fdp=true?fdp=true): FACE HTML > HTML file content saved as "undefined" when using the rich text editor
- [DE43733:](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F600359414369&fdp=true) FACE HTML > clicking 'back' with changes in editor does not trigger discard changes popup

## Description

Backporting the fixes for the above 2 defects.

## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1756
