### PR TITLE
Bump HTML editor version to 1.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.10.tgz",
-      "integrity": "sha512-JjY8xiLq/xnuoC07t64Z2tuZ5vtCScZBFhxJ2L7QuoCx/7FgN22aMinAP4g1xMPYdjjPWxNcuSIctFjZQAJ4uQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.7.11.tgz",
+      "integrity": "sha512-MQyPmomgcEEWw58jEzPYaitgBQR3SHeU2Vk9mpwAELfLoCKQXty1jkMUSxxEjUf+YvbHVB7upCbgjEjxFJ4+qQ==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains the following changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.7.10...v1.7.11