### PR TITLE
DE43937 - Backport `fr-ON` changes in `d2l-rubric` and `activities`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5494,7 +5494,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#25d2fa24d0c13703126f9f0dafc9ce7f09f4e80a",
+      "version": "github:Brightspace/d2l-rubric#fe6527bfb2def8c336374ddb70af95d89832e2f1",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4753,7 +4753,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#cf1b341f9bd754c910b8d708d8516b7838070c59",
+      "version": "github:BrightspaceHypermediaComponents/activities#7a58b1eaf7565f600167aec2bab2e24e8418e144",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
Uses release [v3.8.10 (20.21.6 Hotfix 1)](https://github.com/Brightspace/d2l-rubric/releases/tag/v3.8.10-20.21.6-hotfix-1) from [Brightspace/d2l-rubric](https://github.com/Brightspace/d2l-rubric) and release [v3.164.4](https://github.com/BrightspaceHypermediaComponents/activities/releases/tag/v3.164.4) from [BrightspaceHypermediaComponents/activities](https://github.com/BrightspaceHypermediaComponents/activities).