### PR TITLE
[20.21.7] bump rubrics and consistent eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5502,7 +5502,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#4230d182c41994380c525885e9e33dace768f1f8",
+      "version": "github:Brightspace/d2l-rubric#bef5c0d03a281996bddacc0b7e1df9513fe7ca57",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4925,7 +4925,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#4b26a61c963b56700c5dea9b8bf052bb0d6f7caa",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#687401758f3d02febe0874b22664bc1b3d9ab51d",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",


### PR DESCRIPTION
Rally: [US129073](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F601565647541)

Bumps `d2l-rubric` and `BrightspaceHypermediaComponents/consistent-evaluation` to include the feature flag changes for the new inline rubrics revamp.