### PR TITLE
upgrading to core 1.139.3 to pick up rIC Safari fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,9 +1443,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.139.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.139.2.tgz",
-      "integrity": "sha512-wOEDqYDcaT6hAzxAL1rzHykHdQEOeBb9IIj+CRAa1ZKR0ktpb1dkidy2HDhs0MQRDQNk056BwuUWEDPSdf9Mtw==",
+      "version": "1.139.3",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.139.3.tgz",
+      "integrity": "sha512-YMa8IeEi5fxoiVUu+gKm+dimCH6c+xkMM2SxlagiOZ+sf71MGLXX/pSKlhoWq8WfNO1VnrcVbtxWfTFYZn8cFQ==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",


### PR DESCRIPTION
Picking up [this fix](https://github.com/BrightspaceUI/core/pull/1409) for Safari's lack of requestIdleCallback.