### PR TITLE
intl 3.5.1 picks up Safari fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,9 +1472,9 @@
       }
     },
     "@brightspace-ui/intl": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.5.0.tgz",
-      "integrity": "sha512-LtACe003NPja10qINoGr5oUIUukNVwHWEhM76C/yuIMHquPCeJmC3m7whrDfUP8OzxrcdyOryuZqZj3xFRJuaQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.5.1.tgz",
+      "integrity": "sha512-MM+/GZsn4aYCvk+mmy3Yws2tZvnGQMAd31d5ZDcJL64Fi2jnoUmISs3edIQ9kM8J1Rn/Rj7zHihpLJtYC+LZiQ=="
     },
     "@brightspace-ui/logging": {
       "version": "1.3.0",


### PR DESCRIPTION
Picking up [this fix](https://github.com/BrightspaceUI/intl/pull/89) to Intl for cert into 20.21.7.