### PR TITLE
Bump siren-sdk and activities for DE43998

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4745,7 +4745,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#d28a7bc9ad1b331e284bb875171ab0edfb735bb1",
+      "version": "github:BrightspaceHypermediaComponents/activities#e2fca2e94b9eeadb64d6491c63499703d59209ea",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -11888,7 +11888,7 @@
       "integrity": "sha512-mu6iERPU9mFVGL/fZoKMub51E6yuvfZmeFZhBWuHO5Vyuto3nKhbzk9RmGcFiny/MvNZu8ADHxOBWbtkQnW1nQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#d21c89c5013b296383efe9847e0509f780a278ce",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#56205b5a7ec9e2b4deb14f005f7d40bf7a606dbb",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
## Relevant Rally Links 

[DE43998](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F601841380817&fdp=true): [cert] LTI page - Add link to LTI link entity that will check X-Frame-Options header

## Description

Updating siren-sdk and activities for the above defect, which relates to user story [US128812](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fuserstory%2F600911792617&fdp=true).

## Related PRs

https://github.com/BrightspaceHypermediaComponents/activities/pull/1820
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/349