### PR TITLE
Bump HTML editor version to v1.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,9 +1458,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.11.1.tgz",
-      "integrity": "sha512-Eo2XTD6uPhjjfwweiwmgQ1kYoc2IAXg+uguUjA2fDUE8pvXpCRykLUwdEFJ2gx4XYRc11ELUtbAYkqu759cixA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.11.3.tgz",
+      "integrity": "sha512-JmagkdckT3f+lZjjUSqj9MuF0RElXxz2SS4EajMkJhD2J6PY+/wIY1UeN/S2NwlRehU8PGp/FfKwuY4jIcW85A==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains the following changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.11.1...v1.11.3