### PR TITLE
reapplying dialog button margins since they get zeroed out

### DIFF
--- a/sass/deprecated/button.scss
+++ b/sass/deprecated/button.scss
@@ -65,6 +65,14 @@
 	&[primary]:focus, &[primary].d2l-button-focus {
 		@include _d2l-button-focus();
 	}
+	d2l-dialog-fullscreen &[slot="footer"] {
+		margin-bottom: 18px;
+		margin-right: 18px;
+	}
+	[dir="rtl"] d2l-dialog-fullscreen &[slot="footer"] {
+		margin-left: 18px;
+		margin-right: 0;
+	}
 }
 
 /* these are still referenced by a few FRAs, button-filter-groups, iterator */


### PR DESCRIPTION
This goes along [with this PR](https://github.com/Brightspace/lms/pull/11189#pullrequestreview-687735335) which brings fullscreen dialogs to MVC.

Dialogs [apply some margins](https://github.com/BrightspaceUI/core/blob/master/components/dialog/dialog-styles.js#L117) to the buttons in the footer. But this CSS we're generating for the monolith sets a margin of `0` on all buttons (and overrides the right margins), which has a higher precedence.

So this re-introduces a copy of it... which I don't love but couldn't think of a better solution.