### PR TITLE
DE44116 - Bump htmleditor to v1.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,9 +1458,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.11.3.tgz",
-      "integrity": "sha512-JmagkdckT3f+lZjjUSqj9MuF0RElXxz2SS4EajMkJhD2J6PY+/wIY1UeN/S2NwlRehU8PGp/FfKwuY4jIcW85A==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.11.4.tgz",
+      "integrity": "sha512-QS7v1/VFxAtPsSF8SpPdrduC8klkZaEy5wU8LiS1eBXM8BHLl7kEQOiC1wLFxY1kP2hjWBfl7iNtBYflptBkGA==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.11.3...v1.11.4

Note that the 20.21.6 version of BSI is already pointing at ~1.11, so there's no need to update the package file (just the lock file).