### PR TITLE
F17579/F17878 - Update BSI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4926,7 +4926,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#1cb56b42e6e9961912bf87c7b71e3f6f4bc346ef",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#77d76aced5d889543972034ee3822a89322831ac",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",
@@ -5502,7 +5502,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#d0b5967b2d458201959d75c24d7b6ed2c06c3054",
+      "version": "github:Brightspace/d2l-rubric#3551f345748439e1ed228f5ba6cc500ed1aa7080",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
Update to get latest [v1.225.x](https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/releases/tag/v1.225.2) release of `consistent-evaluation` and the latest release [v3.13.8](https://github.com/Brightspace/d2l-rubric/releases/tag/v3.13.8) of `d2l-rubric`.