### PR TITLE
Update for translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4797,7 +4797,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#06cfee19b0b8be6ec11ff724921f41c5fc79e2eb",
+      "version": "github:Brightspace/d2l-activity-alignments#3dc5e54a6603ec46c545d765ceffe746f7e039ad",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -5502,7 +5502,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#3551f345748439e1ed228f5ba6cc500ed1aa7080",
+      "version": "github:Brightspace/d2l-rubric#046747c94ee29ea140010c13b97d6f7be8b6c5f2",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
Update `d2l-rubric` and `d2l-activity-alignments` to include the release with new translation for cert. Uses https://github.com/Brightspace/d2l-rubric/releases/tag/v3.13.8-20.21.7-certfix-1 and https://github.com/Brightspace/d2l-activity-alignments/releases/tag/v2.1.8.