### PR TITLE
Bump 20.21.7 version of editor to 1.14.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,9 +1459,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.14.4.tgz",
-      "integrity": "sha512-uV1TjLBuP9I5b/K4Xke5aRksij6DmqJvfKNp4mU7wa0MHXEWb5t58e3wmt9W5z0ipv/tt2J1RG4K9SmUuNHsBg==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.14.9.tgz",
+      "integrity": "sha512-S4nb8OCITM2LKIW5ZBz2jT5LJodLMIk5whT/XsQHkHL67Y5+VAhaGcCg6QrdeI+2E18dC1hgqh5XSQZQ1LXWPA==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@brightspace-ui-labs/user-feedback": "^1",
     "@brightspace-ui-labs/user-profile-card": "^0.1.7",
     "@brightspace-ui/core": "^1.114.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "~1.14",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",
     "@brightspace-hmc/foundation-components": "BrightspaceHypermediaComponents/foundation-components.git#semver:^0",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.14.4...v1.14.9

Translations are finally in, so time to bump the 20.21.7 version of the editor!