### PR TITLE
DE44180: Bump activities to v3.175.2c

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4747,7 +4747,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#e2fca2e94b9eeadb64d6491c63499703d59209ea",
+      "version": "github:BrightspaceHypermediaComponents/activities#05e8a2108da0ed71a2017355972200e1c7baeb94",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
Bump activities to v3.175.2c to bring in 20.21.7 translations

This brings in https://github.com/BrightspaceHypermediaComponents/activities/pull/1845