### PR TITLE
Suppress MVC framework validation tooltip in LMS (use the editor component's tooltip instead)

### DIFF
--- a/sass/html-editor/html-editor.scss
+++ b/sass/html-editor/html-editor.scss
@@ -177,6 +177,6 @@
 	}
 }
 
-d2l-htmleditor ~ .vui-validation-bubble {
+d2l-htmleditor + .vui-validation-bubble {
 	display: none;
 }

--- a/sass/html-editor/html-editor.scss
+++ b/sass/html-editor/html-editor.scss
@@ -176,3 +176,7 @@
 		background-color: $d2l-color-sylvite;
 	}
 }
+
+d2l-htmleditor ~ .vui-validation-bubble {
+	display: none;
+}


### PR DESCRIPTION
We're building validation into the editor component, so we would prefer to suppress the MVC framework's tooltip and rely on the component's form validation instead.