### PR TITLE
Remove CSS targeting LMS validation bubble on HTML editor (change wasn't effective everywhere)

### DIFF
--- a/sass/html-editor/html-editor.scss
+++ b/sass/html-editor/html-editor.scss
@@ -176,7 +176,3 @@
 		background-color: $d2l-color-sylvite;
 	}
 }
-
-d2l-htmleditor + .vui-validation-bubble {
-	display: none;
-}


### PR DESCRIPTION
Need to take a slightly different approach to hide the LMS' validation toolti[ on the new HTML editor, since the CSS approach doesn't work everywhere (specifically, if the editor is embedded in a table this doesn't work as expected).