### PR TITLE
DE44358: bump core, mycourses, image-banner in 20.20.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,9 +1445,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.139.4",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.139.4.tgz",
-      "integrity": "sha512-QruuErSfmTeimleLeuSNmh6CzbN7ZK1xsSDI5rb1kzW+NZ6LYvJJuvdyeoB/86PJnNwT848hCyDl4eEoiyd9KQ==",
+      "version": "1.139.5",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.139.5.tgz",
+      "integrity": "sha512-F9RWkR+JNFUMR5LiJp5EsWAtNesUJcNFNsJE5vns5EXyTs8aK4k5XV3GHiWtY410eVnWhJ6hxgDGgLlsqJ1urg==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -5192,7 +5192,7 @@
       }
     },
     "d2l-image-banner-overlay": {
-      "version": "github:Brightspace/d2l-image-banner-overlay#ceb3663c037070479b8bf458f8978e51761d6f5a",
+      "version": "github:Brightspace/d2l-image-banner-overlay#190335cbfcc43252979cb14fe01c5415cbcd3776",
       "from": "github:Brightspace/d2l-image-banner-overlay#semver:^4",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -5275,7 +5275,7 @@
       }
     },
     "d2l-my-courses": {
-      "version": "github:Brightspace/d2l-my-courses-ui#7c1b0cc28915370d040fa52bf0b23f25a6d5f8e0",
+      "version": "github:Brightspace/d2l-my-courses-ui#f6073d64e9a0c24ee87ad77758a1878ac74ec827",
       "from": "github:Brightspace/d2l-my-courses-ui#semver:^11",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5192,7 +5192,7 @@
       }
     },
     "d2l-image-banner-overlay": {
-      "version": "github:Brightspace/d2l-image-banner-overlay#190335cbfcc43252979cb14fe01c5415cbcd3776",
+      "version": "github:Brightspace/d2l-image-banner-overlay#07cd7e3f061ea3b5f4e70bdcb9622102d91c4788",
       "from": "github:Brightspace/d2l-image-banner-overlay#semver:^4",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
The changes are already in 20.20.8. Backporting them to 20.20.7 for an upcoming hotfix. 