### PR TITLE
DE44538: bump core to 1.150.6 in 20.21.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,9 +1478,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.150.5",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.150.5.tgz",
-      "integrity": "sha512-rePoygD7qm+4XeWdaQ81m7P/p9j5IFu4UOQ41dN49EPTq5jMsY78GKFr4WgAxm4l0R050fv6ohuhaCL+UbRAjw==",
+      "version": "1.150.6",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.150.6.tgz",
+      "integrity": "sha512-x+khBYedPEsbXTQ9cHwiE9jLXz2W9FWgmWSk949/+c/cHLxLYhWIT+MkWHqJ7T5/VABHkF0i9dpC7jYXltLqEQ==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",


### PR DESCRIPTION
Includes commit https://github.com/BrightspaceUI/core/commit/c0c0f069323f1775fe9198173630c8dec126e5d1.