### PR TITLE
Bump HTML editor version to 1.14.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1461,9 +1461,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.14.9.tgz",
-      "integrity": "sha512-S4nb8OCITM2LKIW5ZBz2jT5LJodLMIk5whT/XsQHkHL67Y5+VAhaGcCg6QrdeI+2E18dC1hgqh5XSQZQ1LXWPA==",
+      "version": "1.14.10",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.14.10.tgz",
+      "integrity": "sha512-niGMFkv0p4w5xa0axOFObL4WUG/B6Mos7VQ4aHGj+G8+rBpNwQ3BSqoqURYVZZPIr2cXBtUAN4jOkq1tQuMKJQ==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains the following changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.14.9...v1.14.10

The changes not related to the actual emoji dialog were necessary to get semantic-release to work with the default branch renaming. Those won't get pulled into the npm package so won't make their way into BSI.