### PR TITLE
nabrown/cert de44568

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,7 +4803,7 @@
       }
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#2f2c2d2badd4e1c0171a3dde8e85deb17d9fc481",
+      "version": "github:BrightspaceHypermediaComponents/activities#eec93b64aabb40665d76d2f5b6618768d465446b",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",


### PR DESCRIPTION
## Relevant Rally
- [DE44568](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F605247181563&fdp=true?fdp=true): [cert] FACE > HTML Template browse button should have divider

## Relevant PR
https://github.com/BrightspaceHypermediaComponents/activities/pull/1903