### PR TITLE
21.8 Engagment Dashboard Cert Bypass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5151,7 +5151,7 @@
       }
     },
     "d2l-engagement-dashboard": {
-      "version": "github:Brightspace/insights-engagement-dashboard#d3544fe3c01503c7e4b9d9829492f9635ef2534f",
+      "version": "github:Brightspace/insights-engagement-dashboard#39c73da82e94f7ea3f7a71e2ecdc4d432f25b24b",
       "from": "github:Brightspace/insights-engagement-dashboard#semver:^1",
       "requires": {
         "@adobe/lit-mobx": "0.0.x",


### PR DESCRIPTION
Updating the engagement dashboard for the august release. Includes translations, updates to settings form validation, and updated error states. 