### PR TITLE
DE44567 - Update `d2l-rubric` (20.21.8/cert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,7 +5572,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#6a647a64d22e5af46bf94e837cc4fe8581590125",
+      "version": "github:Brightspace/d2l-rubric#f2e7c7089291381b61860e8d1824dc86005e7744",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
Includes https://github.com/Brightspace/d2l-rubric/pull/928.