### PR TITLE
backport DE44396 to 20.21.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,7 +1225,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#0ab73c9a2a5e012ba02ad1bcd1e79eac0c5ec3da",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#9a42dc800ada4cdd332147c75aaa75cb1b52ddc7",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",


### PR DESCRIPTION
See relevant HMC commit: https://github.com/BrightspaceHypermediaComponents/foundation-components/commit/9a42dc800ada4cdd332147c75aaa75cb1b52ddc7

Rally: https://rally1.rallydev.com/#/357251704080ud/iterationstatus?detail=%2Fdefect%2F603983938391&fdp=true?fdp=true