### PR TITLE
backport DE44936 to 20.21.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,7 +1225,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#6efd1472031632f3bcfddaf8d65b214bdacae94c",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#9a42dc800ada4cdd332147c75aaa75cb1b52ddc7",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",


### PR DESCRIPTION
See relevant HMC commit: BrightspaceHypermediaComponents/foundation-components@9a42dc8

Rally: https://rally1.rallydev.com/#/357251704080ud/iterationstatus?detail=%2Fdefect%2F603983938391&fdp=true?fdp=true