### PR TITLE
Bump HTML editor cert release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,9 +1494,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.0.tgz",
-      "integrity": "sha512-RKAYgwVBNLEUZalvh3gMILnLmY9qf6nUd7HguAYHYWHO9mIZUwZm1+PIq+qLH7psJLjUBqwBwg2gG6yiiNT8Yw==",
+      "version": "1.20.7",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.7.tgz",
+      "integrity": "sha512-ZU3yCH/qo6YoV60GRMSWyI3deAaYsiJ6H/lTrfDYOZ9vUFGApZL3+i71G0l3q8KEw92coMauUS8Y9o/AI759zg==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@brightspace-ui-labs/user-feedback": "^1",
     "@brightspace-ui-labs/user-profile-card": "^0.5.3",
     "@brightspace-ui/core": "^1.114.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "~1.20",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",
     "@brightspace-hmc/foundation-components": "BrightspaceHypermediaComponents/foundation-components.git#semver:^0",


### PR DESCRIPTION
Contains the following changes intended for 20.21.8 cert: https://github.com/BrightspaceUI/htmleditor/compare/v1.20.0...v1.20.7