### PR TITLE
Bump editor to v1.20.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,9 +1494,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.20.7",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.7.tgz",
-      "integrity": "sha512-ZU3yCH/qo6YoV60GRMSWyI3deAaYsiJ6H/lTrfDYOZ9vUFGApZL3+i71G0l3q8KEw92coMauUS8Y9o/AI759zg==",
+      "version": "1.20.8",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.8.tgz",
+      "integrity": "sha512-+9xUICCw2vUHsOfUaKSxbDGYNbo0hz0wYjzADfcj215RfCNkKklXaMh7gsESoCPJRdqKp2Y61l4YvotCQvAsZQ==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.20.7...v1.20.8