### PR TITLE
fix: Backport DE44343 and DE44396 to 20.21.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,7 +1225,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#e86a7c78e4a077449d626a9c16eba9c54a5bc0d7",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#b720d76b7d41faa72abedc70848022071a4f1776",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",


### PR DESCRIPTION
See relevant commit in hmc-foundation components here: https://github.com/BrightspaceHypermediaComponents/foundation-components/commit/b720d76b7d41faa72abedc70848022071a4f1776

Rally defects: https://rally1.rallydev.com/#/357251704080/custom/367300408400?detail=%2Fdefect%2F603778332755
https://rally1.rallydev.com/#/357251704080/custom/367300408400?detail=%2Fdefect%2F603983938391

similar PR incoming for 20.21.7