### PR TITLE
Backport missing CE TLs to 20.21.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4988,7 +4988,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#390f4e5330974ca319152aad0526bad56b91d976",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#55f4f11a035844c5d7c22a3454edc7041d0a721b",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/commit/55f4f11a035844c5d7c22a3454edc7041d0a721b