### PR TITLE
Rubric feedback HTML hotfix - DE44765

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,7 +5572,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#858b6f02c4fad351a27c909b8b50e1b83a790c61",
+      "version": "github:Brightspace/d2l-rubric#44900e2695853ed9f6d3d5b401e316f9913870f4",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",


### PR DESCRIPTION
Updating d2l-rubric commit hash with latest hotfix version: https://github.com/Brightspace/d2l-rubric/releases/tag/v3.18.19

Rally ticket: https://rally1.rallydev.com/#/57732444928ud/defects?detail=%2Fdefect%2F606479886631