### PR TITLE
DE44817 - Update `d2l-rubric` (20.21.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5736,7 +5736,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#0f030b924ba7c84d62f82c1e4fc0724cef44f611",
+      "version": "github:Brightspace/d2l-rubric#36fb27ba1ad9a7bed7ae5c0c562e71ec73352774",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2",


### PR DESCRIPTION
hotfix: Includes [55439d3](https://github.com/Brightspace/d2l-rubric/commit/55439d3ecc5528c9beef35fc46fe830141af98af) via [36fb27b](https://github.com/Brightspace/d2l-rubric/commit/36fb27ba1ad9a7bed7ae5c0c562e71ec73352774)