### PR TITLE
DE45126 - Bump editor version to 1.20.11 (HTML conversion fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,9 +1494,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.20.9",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.9.tgz",
-      "integrity": "sha512-H+F6nSspX1zcwC2qO+eRrXDVkaGyRLeqERtLMioS+pn+kTYI8aMswWxeroTVYBYVcKe4EdXATfgm5ZP/30DYog==",
+      "version": "1.20.11",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.11.tgz",
+      "integrity": "sha512-8jn6nP0R/aNXVCMGm9gNxKnM1+6RhmQgKYRvQ4TNOLqDWZ+1lBOtu5AnHqdCKpksYZXhf4kLtrjp3aMiNe9/fg==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.20.9...v1.20.11

The fix in v1.20.10 was never backported into BSI because it's not needed in the core LMS. It's harmless though, so bundling it in here won't cause any issues.