### PR TITLE
DE45125 - Bump editor version to 1.23.2 (HTML conversion fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,9 +1511,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.0.tgz",
-      "integrity": "sha512-9M1wLwHA0NB40imHq4v6AAUbjzZswNC4JzPXCTiF6GhNls0Le1UA86Whj3mfGygI6KFDJyCyJvgFuxVVpC39/Q==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.2.tgz",
+      "integrity": "sha512-UF0POj31xpXqD+HVn9bZNtEiSXcU6i/d6MGPOndxThHT44Y5Q1o6k7eYhU+UyIPQtKJp3YzK0AOq6YGuNZ7Seg==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@brightspace-ui-labs/user-feedback": "^1",
     "@brightspace-ui-labs/user-profile-card": "^0.6",
     "@brightspace-ui/core": "^1.114.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "~1.23",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/logging": "^1.1.0",
     "@brightspace-hmc/foundation-components": "BrightspaceHypermediaComponents/foundation-components.git#semver:^0",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.23.0...v1.23.2

Once again, v1.23.1 contains some misc. changes that shouldn't cause any issues here; just a fix I didn't intend to backport originally, but that certainly can't hurt to backport.