### PR TITLE
Bump HTML editor version (fix head stripping issue)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,9 +1494,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.20.11",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.11.tgz",
-      "integrity": "sha512-8jn6nP0R/aNXVCMGm9gNxKnM1+6RhmQgKYRvQ4TNOLqDWZ+1lBOtu5AnHqdCKpksYZXhf4kLtrjp3aMiNe9/fg==",
+      "version": "1.20.12",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.20.12.tgz",
+      "integrity": "sha512-b4DkfZQ5LfHe/vqdV1vm1bQaaw+Ea347+iyeGXfpYZaiHLlWECusRHS9p9jfP1ctS7orrziJmGb6H6RbuxfiJw==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.20.11...v1.20.12