### PR TITLE
Bump HTML editor version (fix head stripping issue)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,9 +1511,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.2.tgz",
-      "integrity": "sha512-UF0POj31xpXqD+HVn9bZNtEiSXcU6i/d6MGPOndxThHT44Y5Q1o6k7eYhU+UyIPQtKJp3YzK0AOq6YGuNZ7Seg==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.3.tgz",
+      "integrity": "sha512-DSo1DgLiMRHS5fZCkwvmnyoSSAL38GZwfzIVgCSo+BbsM2/VgQu5EZ9jCeYHzg7IaCS+bBcNSpfvoie9G7k7BA==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
Contains these changes: https://github.com/BrightspaceUI/htmleditor/compare/v1.23.2...v1.23.3