### PR TITLE
DE45250 Hotfix for 20.21.9: Bump @brightspace-ui/htmleditor to 1.23.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,9 +1511,9 @@
       }
     },
     "@brightspace-ui/htmleditor": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.3.tgz",
-      "integrity": "sha512-DSo1DgLiMRHS5fZCkwvmnyoSSAL38GZwfzIVgCSo+BbsM2/VgQu5EZ9jCeYHzg7IaCS+bBcNSpfvoie9G7k7BA==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/htmleditor/-/htmleditor-1.23.4.tgz",
+      "integrity": "sha512-pjX7AhoqJdI0VS12JovEfnUCbzYbJ5VTDdU/jlNSXJ+oIz+OKllqgKIljDJrXHbtpYh+9eM1WJR73VZaxpb2yg==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F609569756647