### PR TITLE
US129749 - Remove select-outcomes component from BSI

### DIFF
--- a/web-components/d2l-activity-alignments.js
+++ b/web-components/d2l-activity-alignments.js
@@ -1,4 +1,3 @@
 import 'd2l-activity-alignments/d2l-activity-alignments.js';
-import 'd2l-activity-alignments/d2l-select-outcomes.js';
 import 'd2l-activity-alignments/d2l-activity-alignment-tags.js';
 import 'd2l-activity-alignments/d2l-select-outcomes-hierarchical.js';


### PR DESCRIPTION
https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F603437125947

Part of [Brightspace/lms#14424](https://github.com/Brightspace/lms/pull/14424) - avoids extra conversion of `d2l-select-outcomes` and `d2l-alignment-update` in activity alignments