### PR TITLE
Update 20.21.10 d2l-rubric with hotfix changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5730,7 +5730,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#80fe66911d749cda830dd7e13b982ea2b4cc18c4",
+      "version": "github:Brightspace/d2l-rubric#395083994965240a053be07b82ac88445a2c57b9",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2",


### PR DESCRIPTION
Latest `3.x` version: https://github.com/Brightspace/d2l-rubric/releases/tag/v3.24.4