### PR TITLE
Update 20.21.9 with d2l-rubric hotfix changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5736,7 +5736,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#0015e02eeb2c777126caded966e700bce585561a",
+      "version": "github:Brightspace/d2l-rubric#223e2a803fea7d675bf52451eef78f2107f1b9ab",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2",


### PR DESCRIPTION
Updating with latest `3.23.x` version: https://github.com/Brightspace/d2l-rubric/releases/tag/v3.23.13