### PR TITLE
upgrading logging in 20.21.10 to ignore benign errors (#4741)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,7 +5143,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#245eb9df13bcb86ea99f8e173e961eebee69b2e4",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#42267ffd4ef250d06b5d94eb16d53b2c3513ba3c",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",


### PR DESCRIPTION
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/693