### PR TITLE
De45341 - bump consistent-eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,7 +5143,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#42267ffd4ef250d06b5d94eb16d53b2c3513ba3c",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#9c031449269f9b820b64fd9d4a0266c6fa489360",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",


### PR DESCRIPTION
Bump CE for 20.21.10

[PR](https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/695) for reference