### PR TITLE
DE45729 - CE - Backporting DE45435 (MathML equation fix) to 20.21.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4812,7 +4812,7 @@
       }
     },
     "d2l-consistent-evaluation": {
-      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#1293f47f84f49a7f691b094d3938b44780b06104",
+      "version": "github:BrightspaceHypermediaComponents/consistent-evaluation#e08fd0d4ac04537cc3bd41bed51090a89dae762d",
       "from": "github:BrightspaceHypermediaComponents/consistent-evaluation#semver:^1",
       "requires": {
         "@brightspace-ui-labs/facet-filter-sort": "^4.1.0",


### PR DESCRIPTION
[DE45729 - 20.21.11 Discussions/New Evaluation Experience >Inserted MathML equations does not display while assessing the students post using New Evaluation Experience](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fdefect%2F612634991443)