### PR TITLE
DE45912 backport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,7 +1225,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#66d438ed4de146b49422230881665b3606728484",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#23387ff01d13d17dbaea5ee0a297ec713cf93ef7",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,7 +1225,7 @@
       }
     },
     "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#3372ca53135f6b72a1ed22f39a8caa4b83fa2085",
+      "version": "github:BrightspaceHypermediaComponents/foundation-components#66d438ed4de146b49422230881665b3606728484",
       "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",


### PR DESCRIPTION
## Overview

Backport the fix in https://github.com/BrightspaceHypermediaComponents/foundation-components/pull/340 to `20.21.11`.

### Reason for change

See tickets: 

- [DE45912](https://rally1.rallydev.com/#/?detail=/defect/610442836939&fdp=true): (20.21.11) Work To Do Widget > 20.21.9 > Widget items showing early due date after Daylight Savings Time (Nov 7)
- [DE45455](https://rally1.rallydev.com/#/?detail=/defect/610442836939&fdp=true): Work To Do Widget > 20.21.9 > Widget items showing early due date after Daylight Savings Time (Nov 7)

Also, related slack thread: https://d2l.slack.com/archives/C02HQ2QDZLM/p1636042049216300?thread_ts=1635968795.201400&cid=C02HQ2QDZLM

### Changes summarized

- Update `package-lock` to point to the release commit: https://github.com/BrightspaceHypermediaComponents/foundation-components/tree/release/0.56.x

### Suggested future tasks

None.

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [ ] This isn't a 'quick-and-dirty' job