### PR TITLE
Bump ifrau version in BSI (fix fullscreen bug in FRAs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7328,9 +7328,9 @@
       "dev": true
     },
     "ifrau": {
-      "version": "0.39.3",
-      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.39.3.tgz",
-      "integrity": "sha512-LFPc3UnjJ7UU6v49qMO0SxVIcvRAMKkcYnae/TXZcB8w6VBifwvov6Gsz8OL4wTe1X+3YKFA0U/zEmG0wgzmfA=="
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.39.4.tgz",
+      "integrity": "sha512-yj0eMtMGjasjvRu8TsZL08nLI0rOa5tS0VoIKPgoIIrCSG48mPHCmlwieiR9PW+BDohiK4OdnnCf9FyEO1SeHQ=="
     },
     "ignore": {
       "version": "5.1.8",


### PR DESCRIPTION
Contains these changes: https://github.com/Brightspace/ifrau/compare/v0.39.3...v0.39.4