### PR TITLE
Bump module scheduler to v.1.0.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5208,9 +5208,10 @@
       }
     },
     "d2l-module-scheduler": {
-      "version": "github:Brightspace/module-scheduler#630a65b1501007e52ad7deb3cd6bb7e8b1fef81d",
-      "from": "github:Brightspace/module-scheduler#semver:^1",
+      "version": "github:Brightspace/module-scheduler#31e6126d0955d070d13020cfc11411f609a046ac",
+      "from": "github:Brightspace/module-scheduler#semver:1.0.27",
       "requires": {
+        "@brightspace-ui-labs/multi-select": "^4.2.4",
         "@brightspace-ui-labs/pagination": "^1.0.5",
         "@brightspace-ui/core": "^1",
         "lit-element": "^2.5.1",


### PR DESCRIPTION
Update to v.1.0.27: https://github.com/Brightspace/module-scheduler/commit/31e6126d0955d070d13020cfc11411f609a046ac

Includes module-scheduler changes:
- Tags UI for Module Ignore Strings 
- Minor text update in Ignore List confirmation dialog