### PR TITLE
Bump module-scheduler to v.1.0.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5208,8 +5208,8 @@
       }
     },
     "d2l-module-scheduler": {
-      "version": "github:Brightspace/module-scheduler#31e6126d0955d070d13020cfc11411f609a046ac",
-      "from": "github:Brightspace/module-scheduler#semver:1.0.27",
+      "version": "github:Brightspace/module-scheduler#40a4af452b5b43fe3c07869170d8e3c71c1f788c",
+      "from": "github:Brightspace/module-scheduler#semver:1.0.31",
       "requires": {
         "@brightspace-ui-labs/multi-select": "^4.2.4",
         "@brightspace-ui-labs/pagination": "^1.0.5",


### PR DESCRIPTION
Update to v.1.0.31: https://github.com/Brightspace/module-scheduler/commit/40a4af452b5b43fe3c07869170d8e3c71c1f788c

Includes module-scheduler change for Fetching All Semesters