### PR TITLE
DE46051: [cert] LX > Expand/collapse button in wrong position after expanding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5492,7 +5492,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#3cb67efc02afbaccd1f7b2674564160ecf145b05",
+      "version": "github:BrightspaceHypermediaComponents/sequences#cde257b02d02807ce81d2092e47879e7d935ca23",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",


### PR DESCRIPTION
Bump Sequences from 
V2.37.0: https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v2.37.0 
to V2.37.2 (translations backport): https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v2.37.2,
which also includes changes from
V2.37.1 (defect fix): https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v2.37.1